### PR TITLE
fix: add --hex-resampling flag for categorical rasters (#80)

### DIFF
--- a/cng_datasets/cli.py
+++ b/cng_datasets/cli.py
@@ -40,7 +40,11 @@ def main():
     raster_parser.add_argument("--nodata", type=float, help="NoData value to exclude")
     raster_parser.add_argument("--compression", default="deflate", help="COG compression (deflate, lzw, zstd)")
     raster_parser.add_argument("--blocksize", type=int, default=512, help="COG block size (default: 512)")
-    raster_parser.add_argument("--resampling", default="nearest", help="Resampling method (default: nearest)")
+    raster_parser.add_argument("--resampling", default="nearest", help="Resampling method for COG creation (default: nearest)")
+    raster_parser.add_argument("--hex-resampling", default="average",
+                               help="Resampling method for H3 hex downsampling step (default: average). "
+                                    "Use 'mode' for categorical rasters (land cover, classifications); "
+                                    "averaging produces meaningless non-canonical class codes.")
     raster_parser.add_argument("--target-crs", default="EPSG:4326", help="Output CRS for mosaic (default: EPSG:4326)")
     raster_parser.add_argument("--target-extent", help="Clip bbox 'xmin,ymin,xmax,ymax' in target CRS (mosaic only)")
     raster_parser.add_argument("--target-resolution", type=float, help="Output pixel size in target CRS units (mosaic only)")
@@ -104,6 +108,9 @@ def main():
     raster_workflow_parser.add_argument("--parent-resolutions", type=str, default="0", help="Comma-separated parent H3 resolutions (default: '0')")
     raster_workflow_parser.add_argument("--value-column", default="value", help="Name for raster value column")
     raster_workflow_parser.add_argument("--nodata", type=float, help="NoData value to exclude")
+    raster_workflow_parser.add_argument("--hex-resampling", default="average",
+                                        help="Resampling method for H3 hex downsampling step (default: average). "
+                                             "Use 'mode' for categorical rasters (land cover, classifications).")
     raster_workflow_parser.add_argument("--hex-memory", type=str, default="32Gi", help="Memory per hex job pod (default: 32Gi)")
     raster_workflow_parser.add_argument("--max-parallelism", type=int, default=61, help="Maximum parallel hex jobs (default: 61)")
     raster_workflow_parser.add_argument("--hex-storage", type=str, default="20Gi", help="Ephemeral storage request/limit per hex job pod (default: 20Gi)")
@@ -223,6 +230,7 @@ def _dispatch(args):
                 compression=args.compression,
                 blocksize=args.blocksize,
                 resampling=args.resampling,
+                hex_resampling=args.hex_resampling,
                 target_crs=getattr(args, 'target_crs', 'EPSG:4326'),
                 target_extent=target_extent,
                 target_resolution=getattr(args, 'target_resolution', None),
@@ -329,6 +337,7 @@ def _dispatch(args):
             parent_resolutions=parent_res,
             value_column=args.value_column,
             nodata_value=args.nodata,
+            hex_resampling=args.hex_resampling,
             hex_memory=args.hex_memory,
             max_parallelism=args.max_parallelism,
             hex_storage=args.hex_storage,

--- a/cng_datasets/k8s/workflows.py
+++ b/cng_datasets/k8s/workflows.py
@@ -621,6 +621,7 @@ def generate_raster_workflow(
     parent_resolutions: Optional[List[int]] = None,
     value_column: str = "value",
     nodata_value: Optional[float] = None,
+    hex_resampling: str = "average",
     hex_memory: str = "32Gi",
     max_parallelism: int = 61,
     hex_storage: str = "20Gi",
@@ -668,6 +669,9 @@ def generate_raster_workflow(
         parent_resolutions: List of parent H3 resolutions (default: [0])
         value_column: Name for raster value column (default: "value")
         nodata_value: NoData value to exclude (optional)
+        hex_resampling: Resampling method for H3 hex downsampling (default: "average").
+            Use "mode" for categorical rasters (land cover, classifications) to
+            preserve class codes — averaging yields meaningless non-canonical values.
         hex_memory: Memory per hex pod (default: "32Gi")
         max_parallelism: Max parallel hex pods (default: 61)
         target_extent: Clip bbox (xmin, ymin, xmax, ymax) in EPSG:4326 for mosaic step
@@ -743,7 +747,8 @@ def generate_raster_workflow(
     _generate_raster_hex_job(
         manager, k8s_name, hex_input_url, bucket, output_path, git_repo,
         h3_resolution, parent_resolutions, value_column, nodata_value,
-        hex_memory, max_parallelism, hex_storage=hex_storage, config=config,
+        hex_memory, max_parallelism, hex_storage=hex_storage,
+        hex_resampling=hex_resampling, config=config,
     )
 
     # Generate workflow RBAC
@@ -884,15 +889,16 @@ echo "✓ Preprocess COG complete: {output_cog_url}"
 def _generate_raster_hex_job(
     manager, dataset_name, source_url, bucket, output_path, git_repo,
     h3_resolution, parent_resolutions, value_column, nodata_value,
-    hex_memory, max_parallelism, hex_storage="20Gi", config: ClusterConfig = None,
+    hex_memory, max_parallelism, hex_storage="20Gi",
+    hex_resampling: str = "average", config: ClusterConfig = None,
 ):
     """Generate raster H3 hex tiling job."""
     if config is None:
         config = ClusterConfig()
     parent_res_str = ','.join(map(str, parent_resolutions))
-    
+
     # Build command
-    cng_cmd = f"cng-datasets raster --input \"{source_url}\" --output-parquet s3://{bucket}/{dataset_name}/hex/ --h0-index ${{JOB_COMPLETION_INDEX}} --resolution {h3_resolution} --parent-resolutions {parent_res_str} --value-column {value_column}"
+    cng_cmd = f"cng-datasets raster --input \"{source_url}\" --output-parquet s3://{bucket}/{dataset_name}/hex/ --h0-index ${{JOB_COMPLETION_INDEX}} --resolution {h3_resolution} --parent-resolutions {parent_res_str} --value-column {value_column} --hex-resampling {hex_resampling}"
     if nodata_value is not None:
         cng_cmd += f" --nodata {nodata_value}"
 

--- a/cng_datasets/raster/cog.py
+++ b/cng_datasets/raster/cog.py
@@ -411,6 +411,7 @@ class RasterProcessor:
         compression: str = "deflate",
         blocksize: int = 512,
         resampling: str = "nearest",
+        hex_resampling: str = "average",
         nodata_value: Optional[float] = None,
         target_crs: str = "EPSG:4326",
         target_extent: Optional[tuple] = None,
@@ -435,7 +436,12 @@ class RasterProcessor:
             value_column: Name for the raster value column in parquet
             compression: Compression method for COG (deflate, lzw, zstd, etc.)
             blocksize: Block size for COG tiling
-            resampling: Resampling method (nearest, bilinear, cubic, etc.)
+            resampling: Resampling method for COG creation (default: "nearest")
+            hex_resampling: Resampling method for H3 hex downsampling step
+                (default: "average"). Use "mode" for categorical rasters
+                (land cover, classifications) to preserve class codes; averaging
+                produces meaningless values like 45 from {40, 50}. Accepts any
+                GDAL resampling string: nearest, bilinear, cubic, average, mode, etc.
             nodata_value: NoData value to exclude from H3 conversion
             target_crs: CRS for output (default: EPSG:4326); used when mosaicking
             target_extent: Clip extent (xmin, ymin, xmax, ymax) in target_crs; used when mosaicking
@@ -495,6 +501,7 @@ class RasterProcessor:
         self.compression = compression
         self.blocksize = blocksize
         self.resampling = resampling
+        self.hex_resampling = hex_resampling
         self.read_credentials = read_credentials
         self.write_credentials = write_credentials
         
@@ -764,6 +771,10 @@ class RasterProcessor:
         # intermediate file stays small (MB instead of GB for hi-res rasters).
         pixel_size = _h3_res_to_degrees(self.h3_resolution)
 
+        # Resampling choice matters here: "average" is appropriate for continuous
+        # rasters (elevation, temperature) but corrupts categorical data (land cover)
+        # by producing non-canonical class codes. Categorical datasets should pass
+        # hex_resampling="mode" so each output pixel is the most frequent source class.
         warp_options = gdal.WarpOptions(
             dstSRS='EPSG:4326',
             cutlineWKT=h0_geom_wkt,
@@ -771,7 +782,7 @@ class RasterProcessor:
             outputBounds=(inter_xmin, inter_ymin, inter_xmax, inter_ymax),
             xRes=pixel_size,
             yRes=pixel_size,
-            resampleAlg=gdal.GRA_Average,
+            resampleAlg=self.hex_resampling,
             format='XYZ',
         )
 

--- a/tests/test_k8s_workflows.py
+++ b/tests/test_k8s_workflows.py
@@ -630,6 +630,35 @@ class TestRasterWorkflowGeneration:
             assert self.SOURCE_URL in command_str
 
     @pytest.mark.timeout(5)
+    def test_hex_resampling_default_in_hex_command(self):
+        """Hex job command should include --hex-resampling with the default 'average'."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            generate_raster_workflow(
+                dataset_name="test-raster",
+                source_urls=self.SOURCE_URL,
+                bucket="test-bucket",
+                output_dir=tmpdir,
+            )
+            hex_job = self._load_yaml(Path(tmpdir) / "test-raster-hex.yaml")
+            command_str = str(hex_job["spec"]["template"]["spec"]["containers"][0]["command"])
+            assert "--hex-resampling average" in command_str
+
+    @pytest.mark.timeout(5)
+    def test_hex_resampling_mode_propagates_to_hex_command(self):
+        """hex_resampling='mode' should appear in the generated hex job command (issue #80)."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            generate_raster_workflow(
+                dataset_name="test-categorical",
+                source_urls=self.SOURCE_URL,
+                bucket="test-bucket",
+                output_dir=tmpdir,
+                hex_resampling="mode",
+            )
+            hex_job = self._load_yaml(Path(tmpdir) / "test-categorical-hex.yaml")
+            command_str = str(hex_job["spec"]["template"]["spec"]["containers"][0]["command"])
+            assert "--hex-resampling mode" in command_str
+
+    @pytest.mark.timeout(5)
     def test_raster_workflow_backwards_compat_string(self):
         """source_urls accepts a plain string for backwards compatibility."""
         with tempfile.TemporaryDirectory() as tmpdir:

--- a/tests/test_raster.py
+++ b/tests/test_raster.py
@@ -260,16 +260,30 @@ class TestRasterProcessor:
     def test_raster_processor_init(self, small_raster):
         """Test RasterProcessor initialization."""
         from cng_datasets.raster import RasterProcessor
-        
+
         processor = RasterProcessor(
             input_path=small_raster,
             h3_resolution=6,
             parent_resolutions=[5, 0],
         )
-        
+
         assert processor.h3_resolution == 6
         assert processor.parent_resolutions == [5, 0]
         assert processor.con is not None
+        # Default hex resampling preserves existing behavior for continuous rasters
+        assert processor.hex_resampling == "average"
+
+    @pytest.mark.timeout(60)
+    def test_raster_processor_hex_resampling_mode(self, small_raster):
+        """Categorical datasets should be able to opt into mode resampling (issue #80)."""
+        from cng_datasets.raster import RasterProcessor
+
+        processor = RasterProcessor(
+            input_path=small_raster,
+            h3_resolution=6,
+            hex_resampling="mode",
+        )
+        assert processor.hex_resampling == "mode"
     
     @pytest.mark.timeout(60)
     def test_raster_processor_auto_detect(self, small_raster):
@@ -619,6 +633,71 @@ class TestH3Downsampling:
                 f"Got exact source value {val}; expected a blended average"
             )
             assert 10.0 <= val <= 40.0, f"Averaged value {val} outside source range"
+
+    @requires_gdal_array
+    @pytest.mark.timeout(60)
+    def test_warp_mode_resampling_preserves_categorical_classes(self):
+        """Regression test for issue #80: mode resampling must not blend class codes.
+
+        GRA_Average on categorical data (e.g. land cover class codes {40, 50}) yields
+        meaningless interpolated values (45) that don't map to any real class. GRA_Mode
+        picks the most frequent source class, preserving categorical semantics.
+        """
+        # Categorical raster: checkerboard of class 40 and class 50. Any output
+        # pixel covering a mixed region will average to 45 under GRA_Average but
+        # must remain in {40, 50} under GRA_Mode.
+        width, height = 8, 8
+        xmin, ymin = -105.0, 42.0
+        src_pixel = 0.001
+
+        with tempfile.TemporaryDirectory() as tmp:
+            src_path = os.path.join(tmp, "categorical.tif")
+            driver = gdal.GetDriverByName("GTiff")
+            ds = driver.Create(src_path, width, height, 1, gdal.GDT_Int16)
+            ds.SetGeoTransform([xmin, src_pixel, 0, ymin + height * src_pixel, 0, -src_pixel])
+            srs = osr.SpatialReference()
+            srs.ImportFromEPSG(4326)
+            ds.SetProjection(srs.ExportToWkt())
+            # Alternating 40/50 checkerboard
+            data = np.where(
+                (np.indices((height, width)).sum(axis=0) % 2) == 0, 40, 50
+            ).astype(np.int16)
+            ds.GetRasterBand(1).WriteArray(data)
+            ds.GetRasterBand(1).FlushCache()
+            ds = None
+
+            extent = (xmin, ymin, xmin + width * src_pixel, ymin + height * src_pixel)
+            # Downsample by ~4x so each output pixel mixes source pixels
+            pixel_size = 0.004
+
+            def warp(alg, out_name):
+                out_path = os.path.join(tmp, out_name)
+                result = gdal.Warp(out_path, src_path, options=gdal.WarpOptions(
+                    dstSRS="EPSG:4326",
+                    outputBounds=extent,
+                    xRes=pixel_size,
+                    yRes=pixel_size,
+                    resampleAlg=alg,
+                    format="XYZ",
+                ))
+                assert result is not None
+                result = None
+                with open(out_path) as f:
+                    return [float(l.split()[2]) for l in f if l.strip()]
+
+            avg_vals = warp("average", "avg.xyz")
+            mode_vals = warp("mode", "mode.xyz")
+
+            # Average produces the bug: 45 appears
+            assert any(abs(v - 45.0) < 0.5 for v in avg_vals), (
+                "Expected averaging to produce invalid class code ~45 from {40,50}"
+            )
+            # Mode preserves canonical class codes only
+            for v in mode_vals:
+                assert v in (40.0, 50.0), (
+                    f"Mode resampling produced non-canonical class {v}; "
+                    f"must be one of {{40, 50}}"
+                )
 
     @requires_gdal_array
     @pytest.mark.timeout(60)


### PR DESCRIPTION
## Summary

- Adds `--hex-resampling` CLI flag (on `raster` and `raster-workflow` subcommands) so categorical rasters can opt into `mode` aggregation during H3 hex downsampling.
- Fixes #80: `process_h0_region` hardcoded `gdal.GRA_Average`, silently producing non-canonical class codes (e.g. 45 from {40, 50}) on land-cover datasets. The existing `--resampling` flag only reached `create_cog()`, never this step.
- Default remains `"average"` — no behavior change for continuous rasters (elevation, temperature, NDVI, etc.).

## Fix points

- `cng_datasets/raster/cog.py` — new `hex_resampling` kwarg on `RasterProcessor`; `process_h0_region` now uses `self.hex_resampling` instead of the hardcoded constant.
- `cng_datasets/cli.py` — `--hex-resampling` added to both `raster` and `raster-workflow` parsers and threaded to the constructor / workflow generator.
- `cng_datasets/k8s/workflows.py` — `generate_raster_workflow` accepts `hex_resampling` and injects `--hex-resampling {value}` into the generated hex-job command.

## Usage

For categorical rasters in `data-workflows`:

```bash
cng-datasets raster-workflow --dataset cgls-lc100-2019 \
  --source-url ... --bucket public-land-cover \
  --hex-resampling mode
```

Continuous rasters need no change (default is still `average`).

## Test plan

- [x] `RasterProcessor(hex_resampling="mode")` stores the value; default is `"average"`.
- [x] `gdal.Warp` with `resampleAlg="mode"` on a 40/50 checkerboard preserves class codes in `{40, 50}`; `"average"` produces ~45 (demonstrates the bug).
- [x] Generated hex-job YAML contains `--hex-resampling average` by default and `--hex-resampling mode` when passed.
- [x] Full `test_raster.py` + `test_k8s_workflows.py` suites pass in the project Docker image.

## Follow-up

Previously-processed categorical datasets (CGLS-LC100, NLCD, ESA WorldCover, etc.) need to be re-run with `--hex-resampling mode` — out of scope for this PR.