### PR TITLE
fix: deterministic proj.db selection (require MINOR>=7)

### DIFF
--- a/cng_datasets/raster/cog.py
+++ b/cng_datasets/raster/cog.py
@@ -148,14 +148,56 @@ def _cgroup_cpu_count() -> int:
 # Set GDAL to use exceptions for better error handling
 gdal.UseExceptions()
 
-def _configure_proj():
-    """Find a PROJ database with the correct schema version and configure GDAL to use it.
+# Minimum proj.db schema version (DATABASE.LAYOUT.VERSION.MINOR) accepted by
+# the GDAL/PROJ stack in our image (GDAL 3.13 / PROJ 9.x requires >= 7). A db
+# below this throws "a number >= 7 is expected. It comes from another PROJ
+# installation." for every CRS operation.
+_PROJ_MIN_MINOR = 7
 
-    The container may have multiple proj.db files from different PROJ installations.
-    We use sqlite3 to check the schema minor version and pick one that is >=6,
-    which is required by PROJ 9.x.
-    """
+
+def _proj_db_minor(path: str) -> int:
+    """Return a proj.db's DATABASE.LAYOUT.VERSION.MINOR, or -1 if unreadable."""
     import sqlite3
+    try:
+        conn = sqlite3.connect(path)
+        try:
+            row = conn.execute(
+                "SELECT value FROM metadata WHERE key='DATABASE.LAYOUT.VERSION.MINOR'"
+            ).fetchone()
+        finally:
+            conn.close()
+        return int(row[0]) if row else -1
+    except Exception:
+        return -1
+
+
+def _select_proj_db(candidates, min_minor: int = _PROJ_MIN_MINOR):
+    """Pick the highest-version proj.db from `candidates`.
+
+    Returns the path with the greatest schema MINOR version, but only if it
+    meets `min_minor`; otherwise None. Selecting the maximum (rather than the
+    first acceptable, as before) makes the choice deterministic regardless of
+    filesystem `find` ordering, and the min_minor gate stops us from clobbering
+    GDAL's own configuration with a stale db it cannot use (issue: flaky PROJ
+    'number >= 7 is expected' failures in CI and cluster raster jobs).
+    """
+    best, best_minor = None, -1
+    for path in candidates:
+        minor = _proj_db_minor(path)
+        if minor > best_minor:
+            best, best_minor = path, minor
+    return best if best_minor >= min_minor else None
+
+
+def _configure_proj():
+    """Find the best PROJ database on the system and point GDAL at it.
+
+    The container (and the CI runner) carry multiple proj.db files — a
+    GDAL-compatible one and a stale Ubuntu proj-data one (MINOR == 6) that can
+    take precedence. Choose the highest-version db deterministically; if none
+    meets the minimum, leave GDAL's existing configuration alone rather than
+    forcing a stale db.
+    """
     import subprocess
 
     try:
@@ -164,21 +206,12 @@ def _configure_proj():
             capture_output=True, text=True, timeout=10
         )
         candidates = [p for p in result.stdout.strip().split("\n") if p]
-        for path in candidates:
-            try:
-                conn = sqlite3.connect(path)
-                row = conn.execute(
-                    "SELECT value FROM metadata WHERE key='DATABASE.LAYOUT.VERSION.MINOR'"
-                ).fetchone()
-                conn.close()
-                if row and int(row[0]) >= 6:
-                    proj_dir = os.path.dirname(path)
-                    os.environ["PROJ_DATA"] = proj_dir
-                    os.environ["PROJ_LIB"] = proj_dir
-                    gdal.SetConfigOption("PROJ_DATA", proj_dir)
-                    return
-            except Exception:
-                continue
+        chosen = _select_proj_db(candidates)
+        if chosen is not None:
+            proj_dir = os.path.dirname(chosen)
+            os.environ["PROJ_DATA"] = proj_dir
+            os.environ["PROJ_LIB"] = proj_dir
+            gdal.SetConfigOption("PROJ_DATA", proj_dir)
     except Exception:
         pass
 

--- a/tests/test_raster.py
+++ b/tests/test_raster.py
@@ -961,5 +961,49 @@ class TestAntimeridianSplit:
         assert out.equals(geom)
 
 
+class TestProjDbSelection:
+    """The container (and the CI runner) carry more than one proj.db — a
+    GDAL-compatible one (DATABASE.LAYOUT.VERSION.MINOR >= 7) and a stale
+    Ubuntu proj-data one (MINOR == 6). _configure_proj must deterministically
+    pick the highest-version db and require MINOR >= 7, never letting `find`
+    ordering land it on the stale db (which throws 'a number >= 7 is expected'
+    and would intermittently fail raster jobs)."""
+
+    def _make_proj_db(self, path, minor):
+        import sqlite3
+        os.makedirs(os.path.dirname(path), exist_ok=True)
+        con = sqlite3.connect(path)
+        con.execute("CREATE TABLE metadata (key TEXT, value TEXT)")
+        con.execute(
+            "INSERT INTO metadata VALUES ('DATABASE.LAYOUT.VERSION.MINOR', ?)",
+            (str(minor),),
+        )
+        con.commit(); con.close()
+        return path
+
+    def test_picks_highest_version_regardless_of_order(self, tmp_path):
+        from cng_datasets.raster.cog import _select_proj_db
+        good = self._make_proj_db(str(tmp_path / "gdal" / "proj.db"), 7)
+        stale = self._make_proj_db(str(tmp_path / "ubuntu" / "proj.db"), 6)
+        # `find` order is arbitrary — the stale db must never win.
+        assert _select_proj_db([stale, good]) == good
+        assert _select_proj_db([good, stale]) == good
+
+    def test_returns_none_when_best_below_minimum(self, tmp_path):
+        from cng_datasets.raster.cog import _select_proj_db
+        stale = self._make_proj_db(str(tmp_path / "ubuntu" / "proj.db"), 6)
+        # No qualifying db -> return None so the caller leaves GDAL's own
+        # configuration untouched rather than clobbering it with a stale db.
+        assert _select_proj_db([stale]) is None
+
+    def test_ignores_unreadable_candidates(self, tmp_path):
+        from cng_datasets.raster.cog import _select_proj_db
+        bad = tmp_path / "broken" / "proj.db"
+        os.makedirs(bad.parent, exist_ok=True)
+        bad.write_text("not a sqlite database")
+        good = self._make_proj_db(str(tmp_path / "gdal" / "proj.db"), 9)
+        assert _select_proj_db([str(bad), good]) == good
+
+
 if __name__ == "__main__":
     pytest.main([__file__, "-v"])


### PR DESCRIPTION
## Problem

`_configure_proj()` (runs at `import cog`) scanned `find /usr /opt /root -name proj.db` and used the **first** db with `DATABASE.LAYOUT.VERSION.MINOR >= 6`. But the GDAL 3.13 / PROJ 9.x stack in our image requires **>= 7**. The image (and the CI runner) carry two proj.db files — a compatible one and the stale Ubuntu `proj-data` one (MINOR=6) — and `find` order is nondeterministic, so it could land on the stale db and **override GDAL's own (and the Dockerfile's) correct `PROJ_DATA`**, throwing:

```
PROJ: ... proj.db contains DATABASE.LAYOUT.VERSION.MINOR = 6 whereas a number >= 7
is expected. It comes from another PROJ installation.
```

for every CRS operation.

This is **flaky**: it passed CI for #85 but failed for #86 on the identical code, and — because `_configure_proj` runs in every worker process — it could **intermittently fail cluster raster jobs**, including the GHS-POP reprocessing kicked off after #85.

## Fix

- Pick the **highest-version** proj.db deterministically (same logic the Dockerfile already uses at build time), instead of the first acceptable one.
- Require `MINOR >= 7`; if none qualifies, **leave GDAL's configuration untouched** rather than forcing a stale db.
- Extracted `_select_proj_db` as a pure helper with unit tests (highest-version-wins regardless of order; None below minimum; ignores unreadable candidates).

## Test

`tests/test_raster.py::TestProjDbSelection` (3 new, no GDAL needed). Full raster suite green in the project Docker image (26 passed). Lint-neutral.

Recommend merging before the GHS-POP reprocessing and before rebasing #86 (whose CI red was this exact flake).