### PR TITLE
fix: handle polar antimeridian cells in _split_antimeridian (#92)

### DIFF
--- a/cng_datasets/raster/cog.py
+++ b/cng_datasets/raster/cog.py
@@ -29,29 +29,47 @@ def _split_antimeridian(geom):
     of +180), split the unwrapped polygon at x=180, and translate the eastern
     piece back by -360 — yielding two small polygons hugging +180 and -180.
     Non-wrapping geometries are returned unchanged.
+
+    A cell touching both +/-180 and a pole unwraps to a self-intersecting ring
+    near lat ~90 (all meridians converge, so the boundary spans a huge longitude
+    range), which GEOS cannot intersect or union — it raises a TopologyException
+    that kills the whole worker process (issue #92). We make_valid the unwrapped
+    ring first (which resolves that self-intersection into the cell's true polar
+    footprint), and guard the whole helper so any remaining pathological cell
+    falls back to a valid copy of the original rather than crashing the worker.
     """
     minx, _, maxx, _ = geom.bounds
     if maxx - minx <= 180:
         return geom
 
+    from shapely import make_valid
     from shapely.geometry import Polygon, box
     from shapely.affinity import translate
     from shapely.ops import unary_union
+    from shapely.errors import GEOSException
 
-    unwrapped = Polygon([(x + 360.0 if x < 0 else x, y)
-                         for x, y in geom.exterior.coords])
-    uminx, uminy, umaxx, umaxy = unwrapped.bounds
-    west = unwrapped.intersection(box(uminx, uminy, 180.0, umaxy))
-    east = unwrapped.intersection(box(180.0, uminy, umaxx, umaxy))
+    try:
+        unwrapped = make_valid(Polygon([(x + 360.0 if x < 0 else x, y)
+                                        for x, y in geom.exterior.coords]))
+        uminx, uminy, umaxx, umaxy = unwrapped.bounds
+        west = unwrapped.intersection(box(uminx, uminy, 180.0, umaxy))
+        east = unwrapped.intersection(box(180.0, uminy, umaxx, umaxy))
 
-    parts = []
-    if not west.is_empty:
-        parts.append(west)
-    if not east.is_empty:
-        parts.append(translate(east, xoff=-360.0))
-    if not parts:
-        return geom
-    return unary_union(parts)
+        parts = []
+        if not west.is_empty:
+            parts.append(west)
+        if not east.is_empty:
+            parts.append(translate(east, xoff=-360.0))
+        if not parts:
+            return geom
+        return unary_union(parts)
+    except GEOSException:
+        # Last resort: hand exact_extract a valid geometry so the worker
+        # survives. A polar cell's true footprint is a tiny cap near +/-90,
+        # where raster sources almost never have data, so even an unsplit
+        # fallback contributes ~no mass.
+        valid = make_valid(geom)
+        return valid if not valid.is_empty else geom
 
 
 def _exact_extract_chunk(args):

--- a/tests/test_raster.py
+++ b/tests/test_raster.py
@@ -960,6 +960,31 @@ class TestAntimeridianSplit:
         out = _split_antimeridian(geom)
         assert out.equals(geom)
 
+    def test_handles_polar_seam_cell(self):
+        """Issue #92: a cell touching both +/-180 and a pole unwraps to a
+        self-intersecting ring near lat ~90 that GEOS cannot split — the
+        box intersection / unary_union raises a GEOSException that kills the
+        whole worker process, so the affected h0 partition is never written.
+        The helper must return a valid, non-empty geometry instead of raising.
+
+        Fixture is the real boundary of h9 617048546304851967
+        (h3_latlng_to_cell(89.999, 0.0, 9)), the pole cell that triggers it.
+        """
+        from cng_datasets.raster.cog import _split_antimeridian
+        from shapely import wkt as shapely_wkt
+
+        polar = ("POLYGON ((11.400728 89.998110, 86.369271 89.999144, "
+                 "-159.168809 89.998601, -110.483110 89.997514, "
+                 "-71.709687 89.997041, -32.485280 89.997285, "
+                 "11.400728 89.998110))")
+        geom = shapely_wkt.loads(polar)
+        assert geom.bounds[2] - geom.bounds[0] > 180, "fixture should wrap"
+
+        fixed = _split_antimeridian(geom)  # must not raise
+
+        assert fixed.is_valid, "split produced an invalid geometry"
+        assert not fixed.is_empty, "split dropped the cell entirely"
+
 
 class TestProjDbSelection:
     """The container (and the CI runner) carry more than one proj.db — a


### PR DESCRIPTION
## Summary
- Fixes #92: `_split_antimeridian` threw `GEOSException: TopologyException` and killed the whole `exact_extract` worker for H3 cells touching **both** the ±180° seam **and** a pole, leaving those h0 partitions unwritten.
- At a pole all meridians converge, so the cell's lat/lng boundary spans a huge longitude range; after unwrapping (`x+360 if x<0`) the ring is self-intersecting near lat≈90 and the subsequent `box` intersection / `unary_union` raised in GEOS.
- `make_valid` the unwrapped ring before splitting — this resolves the self-intersection into the cell's true polar footprint, and the split then succeeds — and guard the whole helper in a `try/except GEOSException` that falls back to a valid copy of the original cell so any remaining pathological geometry can never crash a worker again.

## Test Plan
- [x] New unit test `TestAntimeridianSplit::test_handles_polar_seam_cell` on the pole cell `h3_latlng_to_cell(89.999, 0, 9)` — RED before the fix (GEOSException), GREEN after; asserts the result is valid and non-empty.
- [x] Existing antimeridian tests still pass (non-polar seam cell still splits to ~6.6e-6 deg² parts hugging ±180 — no regression).
- [x] Full raster suite green: `pytest tests/test_raster.py` → 31 passed (run in `ghcr.io/boettiger-lab/datasets:latest` + `exactextract`).
- [ ] Re-run GHS-POP h0 indices 28 & 115 once merged (resume-safe).