### PR TITLE
fix(#90): clear ruff lint backlog and make CI lint blocking

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -53,4 +53,3 @@ jobs:
     - name: Lint with ruff
       run: |
         ruff check cng_datasets/ --select E,F,W --ignore E501
-      continue-on-error: true

--- a/.gitignore
+++ b/.gitignore
@@ -229,3 +229,6 @@ node_modules/
 build/
 *.egg-info/
 node_modules/
+
+# Local Claude Code session/worktree state
+.claude/

--- a/cng_datasets/__init__.py
+++ b/cng_datasets/__init__.py
@@ -7,7 +7,7 @@ A toolkit for processing large geospatial datasets into cloud-native formats
 
 __version__ = "0.1.1"
 
-# Lazy imports can be handled by users as needed, 
+# Lazy imports can be handled by users as needed,
 # or we can keep these commented out to allow core usage without all dependencies.
 # from . import vector, raster, k8s, storage
 # __all__ = ["vector", "raster", "k8s", "storage", "__version__"]

--- a/cng_datasets/cli.py
+++ b/cng_datasets/cli.py
@@ -14,9 +14,9 @@ def main():
         description="Cloud-native geospatial dataset processing toolkit",
         formatter_class=argparse.RawDescriptionHelpFormatter,
     )
-    
+
     subparsers = parser.add_subparsers(dest="command", help="Available commands")
-    
+
     # Vector processing command
     vector_parser = subparsers.add_parser("vector", help="Process vector datasets")
     vector_parser.add_argument("--input", required=True, help="Input file URL")
@@ -28,7 +28,7 @@ def main():
     vector_parser.add_argument("--parent-resolutions", type=str, default="9,8,0", help="Comma-separated parent H3 resolutions (default: '9,8,0')")
     vector_parser.add_argument("--id-column", help="ID column name (auto-detected if not specified)")
 
-    
+
     # Raster processing command
     raster_parser = subparsers.add_parser("raster", help="Process raster datasets")
     raster_parser.add_argument("--input", required=True, action="append", dest="inputs",
@@ -78,7 +78,7 @@ def main():
     repartition_parser.add_argument("--source-parquet", required=True, help="Source parquet with full attributes")
     repartition_parser.add_argument("--cleanup", action="store_true", default=True, help="Remove chunks after repartitioning")
     repartition_parser.add_argument("--memory-limit", type=str, default=None, help="DuckDB memory limit (e.g. '27GiB'). Overrides DUCKDB_MEMORY_LIMIT env var.")
-    
+
     # K8s job generation command
     k8s_parser = subparsers.add_parser("k8s", help="Generate Kubernetes job")
     k8s_parser.add_argument("--job-name", required=True, help="Job name")
@@ -86,7 +86,7 @@ def main():
     k8s_parser.add_argument("--output", default="job.yaml", help="Output YAML file")
     k8s_parser.add_argument("--chunks", type=int, help="Number of chunks for indexed job")
     k8s_parser.add_argument("--namespace", default="biodiversity", help="Kubernetes namespace (default: biodiversity)")
-    
+
     # Workflow generation command
     workflow_parser = subparsers.add_parser("workflow", help="Generate complete dataset workflow")
     workflow_parser.add_argument("--dataset", required=True, help="Dataset name (e.g., redlining)")
@@ -163,27 +163,27 @@ def main():
     sync_job_parser.add_argument("--cpu", default="2", help="CPU request/limit (default: 2)")
     sync_job_parser.add_argument("--memory", default="4Gi", help="Memory request/limit (default: 4Gi)")
     sync_job_parser.add_argument("--dry-run", action="store_true", help="Dry run mode (show what would be synced)")
-    
+
     # Storage management command
     storage_parser = subparsers.add_parser("storage", help="Manage cloud storage")
     storage_subparsers = storage_parser.add_subparsers(dest="storage_command")
-    
+
     cors_parser = storage_subparsers.add_parser("cors", help="Configure bucket CORS")
     cors_parser.add_argument("--bucket", required=True, help="Bucket name")
     cors_parser.add_argument("--endpoint", help="S3 endpoint URL")
-    
+
     sync_parser = storage_subparsers.add_parser("sync", help="Sync with rclone")
     sync_parser.add_argument("--source", required=True, help="Source path")
     sync_parser.add_argument("--destination", required=True, help="Destination path")
     sync_parser.add_argument("--dry-run", action="store_true", help="Dry run mode")
-    
+
     setup_bucket_parser = storage_subparsers.add_parser("setup-bucket", help="Setup public bucket with CORS")
     setup_bucket_parser.add_argument("--bucket", required=True, help="Bucket name")
     setup_bucket_parser.add_argument("--remote", default="nrp", help="Rclone remote name (default: nrp)")
     setup_bucket_parser.add_argument("--endpoint", help="S3 endpoint URL (defaults to AWS_PUBLIC_ENDPOINT env var)")
     setup_bucket_parser.add_argument("--no-cors", action="store_true", help="Skip CORS configuration")
     setup_bucket_parser.add_argument("--verify", action="store_true", help="Verify bucket configuration after setup")
-    
+
     args = parser.parse_args()
 
     if not args.command:
@@ -212,7 +212,7 @@ def _dispatch(args):
             intermediate_chunk_size=args.intermediate_chunk_size,
             id_column=args.id_column,
         )
-    
+
     elif args.command == "raster":
         from .raster import RasterProcessor, create_mosaic_cog
 
@@ -270,7 +270,7 @@ def _dispatch(args):
                     processor.process_h0_region()
                 else:
                     processor.process_all_h0_regions()
-    
+
     elif args.command == "repartition":
         from .vector import repartition_by_h0
         repartition_by_h0(
@@ -280,7 +280,7 @@ def _dispatch(args):
             cleanup=args.cleanup,
             memory_limit=args.memory_limit,
         )
-    
+
     elif args.command == "k8s":
         from .k8s import K8sJobManager
         manager = K8sJobManager(namespace=getattr(args, 'namespace', 'biodiversity'))
@@ -296,7 +296,7 @@ def _dispatch(args):
                 command=args.container_command,
             )
         manager.save_job_yaml(job_spec, args.output)
-    
+
     elif args.command == "sync-job":
         from .k8s import generate_sync_job
         generate_sync_job(
@@ -309,7 +309,7 @@ def _dispatch(args):
             memory=args.memory,
             dry_run=args.dry_run,
         )
-    
+
     elif args.command == "workflow":
         from .k8s import generate_dataset_workflow
         # Parse parent resolutions from comma-separated string
@@ -397,7 +397,7 @@ def _dispatch(args):
             from .storage import setup_public_bucket
             from .storage.setup_bucket import verify_bucket_config
             import json
-            
+
             success = setup_public_bucket(
                 bucket_name=args.bucket,
                 remote=args.remote,
@@ -405,12 +405,12 @@ def _dispatch(args):
                 set_cors=not args.no_cors,
                 verbose=True
             )
-            
+
             if success and args.verify:
                 print("\nVerifying configuration...")
                 results = verify_bucket_config(args.bucket, args.endpoint)
                 print(json.dumps(results, indent=2))
-            
+
             sys.exit(0 if success else 1)
 
 

--- a/cng_datasets/k8s/jobs.py
+++ b/cng_datasets/k8s/jobs.py
@@ -7,16 +7,15 @@ dataset processing on clusters.
 
 from typing import Optional, Dict, Any, List
 import yaml
-from pathlib import Path
 
 
 class K8sJobManager:
     """
     Manage Kubernetes jobs for dataset processing.
-    
+
     Generates job YAML configurations and submits them to a Kubernetes cluster.
     """
-    
+
     def __init__(
         self,
         namespace: str = "biodiversity",
@@ -26,7 +25,7 @@ class K8sJobManager:
     ):
         """
         Initialize the K8s job manager.
-        
+
         Args:
             namespace: Kubernetes namespace for jobs
             image: Container image to use
@@ -37,7 +36,7 @@ class K8sJobManager:
         self.image = image
         self.service_account = service_account
         self.secrets = secrets or []
-    
+
     def generate_job_yaml(
         self,
         job_name: str,
@@ -52,7 +51,7 @@ class K8sJobManager:
     ) -> Dict[str, Any]:
         """
         Generate Kubernetes job specification.
-        
+
         Args:
             job_name: Name for the job
             command: Container command
@@ -63,7 +62,7 @@ class K8sJobManager:
             completions: Number of job completions needed
             parallelism: Number of parallel pods
             restart_policy: Pod restart policy
-            
+
         Returns:
             Job specification as dictionary
         """
@@ -93,20 +92,20 @@ class K8sJobManager:
                 }
             }
         }
-        
+
         # Add arguments if provided
         if args:
             job_spec["spec"]["template"]["spec"]["containers"][0]["args"] = args
-        
+
         # Add environment variables
         if env_vars:
             env_list = [{"name": k, "value": v} for k, v in env_vars.items()]
             job_spec["spec"]["template"]["spec"]["containers"][0]["env"] = env_list
-        
+
         # Add service account if specified
         if self.service_account:
             job_spec["spec"]["template"]["spec"]["serviceAccountName"] = self.service_account
-        
+
         # Add secrets if specified
         if self.secrets:
             volumes = []
@@ -123,9 +122,9 @@ class K8sJobManager:
                 })
             job_spec["spec"]["template"]["spec"]["volumes"] = volumes
             job_spec["spec"]["template"]["spec"]["containers"][0]["volumeMounts"] = volume_mounts
-        
+
         return job_spec
-    
+
     def generate_chunked_job(
         self,
         job_name: str,
@@ -136,21 +135,21 @@ class K8sJobManager:
     ) -> Dict[str, Any]:
         """
         Generate a job for processing data in chunks.
-        
+
         Args:
             job_name: Base name for the job
             script_path: Path to processing script in container
             num_chunks: Total number of chunks to process
             base_args: Base arguments for the script
             **kwargs: Additional arguments passed to generate_job_yaml
-            
+
         Returns:
             Job specification with indexed completions
         """
         # Use indexed completions for chunk processing
         args = base_args or []
         args.extend(["--i", "$(INDEX)"])
-        
+
         job_spec = self.generate_job_yaml(
             job_name=job_name,
             command=["python", script_path],
@@ -159,12 +158,12 @@ class K8sJobManager:
             parallelism=kwargs.pop("parallelism", min(num_chunks, 10)),
             **kwargs
         )
-        
+
         # Add completion index for chunk processing
         job_spec["spec"]["completionMode"] = "Indexed"
-        
+
         return job_spec
-    
+
     def save_job_yaml(self, job_spec: Dict[str, Any], output_path: str):
         """Save job specification to YAML file."""
         # Custom representer for multi-line strings to use literal style
@@ -172,20 +171,20 @@ class K8sJobManager:
             if '\n' in data:
                 return dumper.represent_scalar('tag:yaml.org,2002:str', data, style='|')
             return dumper.represent_scalar('tag:yaml.org,2002:str', data)
-        
+
         yaml.add_representer(str, str_representer)
-        
+
         with open(output_path, 'w') as f:
             yaml.dump(job_spec, f, default_flow_style=False, sort_keys=False)
         print(f"Job YAML saved to {output_path}")
-    
+
     def submit_job(self, job_spec: Dict[str, Any]) -> str:
         """
         Submit job to Kubernetes cluster.
-        
+
         Args:
             job_spec: Job specification dictionary
-            
+
         Returns:
             Job name
         """
@@ -201,13 +200,13 @@ def generate_job_yaml(
 ) -> Dict[str, Any]:
     """
     Convenience function to generate a job YAML specification.
-    
+
     Args:
         job_name: Name for the job
         command: Container command
         namespace: Kubernetes namespace
         **kwargs: Additional arguments passed to K8sJobManager
-        
+
     Returns:
         Job specification dictionary
     """
@@ -218,10 +217,10 @@ def generate_job_yaml(
 def submit_job(job_spec: Dict[str, Any]) -> str:
     """
     Submit a job to Kubernetes cluster.
-    
+
     Args:
         job_spec: Job specification dictionary
-        
+
     Returns:
         Job name
     """

--- a/cng_datasets/k8s/workflows.py
+++ b/cng_datasets/k8s/workflows.py
@@ -5,7 +5,7 @@ Functions for creating complete dataset processing workflows with
 multiple coordinated Kubernetes jobs.
 """
 
-from dataclasses import dataclass, field
+from dataclasses import dataclass
 from typing import Optional, Dict, Any, List, Union
 from pathlib import Path
 import math
@@ -187,33 +187,33 @@ def _count_source_features(source_urls: Union[str, List[str]], layer: str = None
     """
     Count features in source file(s) (shapefile, geopackage, etc.) using GDAL with vsicurl.
     For .zip files, it downloads, extracts, and counts features in all shapefiles.
-    
+
     Args:
         source_urls: HTTP(S) or S3 URL(s) to source vector file(s). Can be a single string or list.
         layer: Optional layer name for multi-layer sources (GDB, GPKG)
-        
+
     Returns:
         Total number of features across all source file(s)
     """
     # Normalize to list
     if isinstance(source_urls, str):
         source_urls = [source_urls]
-    
+
     total_count = 0
     for source_url in source_urls:
         total_count += _count_single_source(source_url, layer)
-    
+
     return total_count
 
 
 def _count_single_source(source_url: str, layer: str = None) -> int:
     """
     Count features in a single source file.
-    
+
     Args:
         source_url: HTTP(S) or S3 URL to source vector file
         layer: Optional layer name for multi-layer sources (GDB, GPKG)
-        
+
     Returns:
         Number of features in the source file
     """
@@ -223,38 +223,38 @@ def _count_single_source(source_url: str, layer: str = None) -> int:
     import shutil
     import zipfile
     from urllib.request import urlretrieve
-    
+
     # Check for zip file
     if source_url.lower().endswith('.zip'):
         try:
-            print(f"  Detected zip file, downloading to temporary directory...")
+            print("  Detected zip file, downloading to temporary directory...")
             temp_dir = tempfile.mkdtemp()
             local_zip = os.path.join(temp_dir, "download.zip")
-            
+
             # Handle S3 vs HTTP
             download_url = source_url
             if source_url.startswith('s3://'):
                  if "nrp-nautilus.io" in source_url or "public-iucn" in source_url:
                      path = source_url.replace("s3://", "")
                      download_url = f"https://s3-west.nrp-nautilus.io/{path}"
-            
+
             # Strip vsicurl if present (legacy compat)
             if download_url.startswith('/vsicurl/'):
                 download_url = download_url.replace('/vsicurl/', '')
-            
+
             if download_url.startswith('http://') or download_url.startswith('https://') or download_url.startswith('ftp://'):
                 urlretrieve(download_url, local_zip)
             elif os.path.exists(download_url):
                 shutil.copy(download_url, local_zip)
             else:
-                 # Try adding file:// scheme if it looks like an absolute path but failed above checks? 
+                 # Try adding file:// scheme if it looks like an absolute path but failed above checks?
                  # Or just let urlretrieve try if it has a scheme.
                  urlretrieve(download_url, local_zip)
 
-            
+
             with zipfile.ZipFile(local_zip, 'r') as zip_ref:
                 zip_ref.extractall(temp_dir)
-                
+
             # Find all shapefiles
             total_count = 0
             shapefiles = []
@@ -262,12 +262,12 @@ def _count_single_source(source_url: str, layer: str = None) -> int:
                 for file in files:
                     if file.lower().endswith(".shp"):
                         shapefiles.append(os.path.join(root, file))
-            
+
             if not shapefiles:
                 raise ValueError("No shapefiles found in zip archive")
-                
+
             print(f"  Found {len(shapefiles)} shapefiles, counting features...")
-            
+
             for shp in shapefiles:
                 result = subprocess.run(
                     ['ogrinfo', '-so', '-al', shp],
@@ -275,13 +275,13 @@ def _count_single_source(source_url: str, layer: str = None) -> int:
                     text=True,
                     check=True
                 )
-                
+
                 for line in result.stdout.split('\n'):
                     if 'Feature Count:' in line:
                         count = int(line.split(':')[1].strip())
                         total_count += count
                         break
-            
+
             return total_count
 
         finally:
@@ -292,13 +292,13 @@ def _count_single_source(source_url: str, layer: str = None) -> int:
     if source_url.startswith('s3://'):
         path = source_url.replace('s3://', '')
         source_url = f"https://s3-west.nrp-nautilus.io/{path}"
-    
+
     # Use vsicurl prefix for remote files
     if source_url.startswith('http://') or source_url.startswith('https://'):
         gdal_path = f"/vsicurl/{source_url}"
     else:
         gdal_path = source_url
-    
+
     # Use ogrinfo to count features
     if layer:
         # Query specific layer for multi-layer sources (GDB, GPKG)
@@ -318,13 +318,13 @@ def _count_single_source(source_url: str, layer: str = None) -> int:
             check=True,
             timeout=30,
         )
-    
+
     # Parse output to find "Feature Count: XXXXX"
     for line in result.stdout.split('\n'):
         if 'Feature Count:' in line:
             count_str = line.split(':')[1].strip()
             return int(count_str)
-    
+
     raise ValueError("Could not find feature count in ogrinfo output")
 
 
@@ -382,24 +382,24 @@ _DEFAULT_H3_RESOLUTION = {
 def _calculate_chunking(total_rows: int, max_completions: int = 200, max_parallelism: int = 50) -> tuple[int, int, int]:
     """
     Calculate optimal chunk size, completions, and parallelism.
-    
+
     Args:
         total_rows: Total number of rows/features in dataset
         max_completions: Maximum number of job completions (default: 200)
         max_parallelism: Maximum parallelism (default: 50)
-        
+
     Returns:
         Tuple of (chunk_size, completions, parallelism)
     """
     # Calculate chunk size to stay under max_completions
     chunk_size = math.ceil(total_rows / max_completions)
-    
+
     # Calculate actual number of completions needed
     completions = math.ceil(total_rows / chunk_size)
-    
+
     # Set parallelism to min of max_parallelism or completions
     parallelism = min(max_parallelism, completions)
-    
+
     return chunk_size, completions, parallelism
 
 
@@ -503,7 +503,7 @@ def generate_dataset_workflow(
         h3_resolution = _DEFAULT_H3_RESOLUTION.get(geom_type, 10)
         print(f"  Detected geometry type: {geom_type} — using H3 resolution {h3_resolution}")
         if geom_type == 'line':
-            print(f"  Line geometries will be buffered before H3 polyfill for continuous cell coverage.")
+            print("  Line geometries will be buffered before H3 polyfill for continuous cell coverage.")
 
     # Set defaults for parent resolutions if not provided
     if parent_resolutions is None:
@@ -517,7 +517,7 @@ def generate_dataset_workflow(
 
     # Generate pmtiles job (uses converted parquet, not source)
     _generate_pmtiles_job(manager, k8s_name, None, bucket, output_path, git_repo, memory=hex_memory, s3_dataset=dataset_name, config=config)
-    
+
     # Count features in source file(s) and calculate chunking parameters
     if len(source_urls) > 1:
         print(f"Counting features in {len(source_urls)} sources...")
@@ -536,21 +536,21 @@ def generate_dataset_workflow(
         total_rows = max_completions * 1000  # Conservative: covers up to max_completions*1000 features
         chunk_size, completions, parallelism = _calculate_chunking(total_rows, max_completions=max_completions, max_parallelism=max_parallelism)
         print(f"  Warning: feature count unknown — defaults cover at most {total_rows:,} features (chunk_size={chunk_size}).")
-        print(f"  If your dataset is larger, set --chunk-size manually.")
+        print("  If your dataset is larger, set --chunk-size manually.")
         print(f"  Using defaults: chunk_size={chunk_size}, completions={completions}, parallelism={parallelism}")
-    
+
     print(f"  H3 resolution: {h3_resolution}")
     print(f"  Parent resolutions: {parent_resolutions}")
-    
+
     # Generate hex tiling job
     _generate_hex_job(manager, k8s_name, bucket, output_path, git_repo, chunk_size, completions, parallelism, h3_resolution, parent_resolutions, id_column, hex_memory, intermediate_chunk_size, s3_dataset=dataset_name, hex_storage=hex_storage, config=config)
 
     # Generate repartition job
     _generate_repartition_job(manager, k8s_name, bucket, output_path, git_repo, s3_dataset=dataset_name, repartition_storage=repartition_storage, repartition_memory=repartition_memory, config=config)
-    
+
     # Generate workflow RBAC (generic for all cng-datasets workflows)
     _generate_workflow_rbac(namespace, output_path)
-    
+
     # Build generation command for documentation
     parent_res_str = ','.join(map(str, parent_resolutions))
     # Format source URLs for command recreation
@@ -558,13 +558,13 @@ def generate_dataset_workflow(
     gen_command = (f"cng-datasets workflow --dataset {dataset_name} "
                    f"{source_urls_str} --bucket {bucket} "
                    f"--h3-resolution {h3_resolution} --parent-resolutions \"{parent_res_str}\"")
-    
+
     # Generate ConfigMap YAML from job files
     _generate_configmap(k8s_name, namespace, output_path, gen_command)
-    
+
     # Generate Argo workflow with ConfigMap-based approach
     _generate_argo_workflow(k8s_name, namespace, output_path, output_dir)
-    
+
     if backend == "armada":
         armada_files = convert_workflow_to_armada(
             k8s_yaml_dir=str(output_path),
@@ -575,13 +575,13 @@ def generate_dataset_workflow(
         print(f"\nArmada files created in {output_dir}:")
         for f in armada_files:
             print(f"  - {Path(f).name}")
-        print(f"\nTo run (submit each step in order):")
+        print("\nTo run (submit each step in order):")
         steps = ["setup-bucket", "convert", "pmtiles", "hex", "repartition"]
         for step in steps:
             armada_file = output_path / f"armada-{k8s_name}-{step}.yaml"
             if armada_file.exists():
                 print(f"  armadactl submit {output_dir}/armada-{k8s_name}-{step}.yaml")
-        print(f"\nMonitor at: https://armada-lookout.nrp-nautilus.io")
+        print("\nMonitor at: https://armada-lookout.nrp-nautilus.io")
     else:
         print(f"\n✓ Generated complete workflow for {dataset_name}")
         print(f"\nFiles created in {output_dir}:")
@@ -590,21 +590,21 @@ def generate_dataset_workflow(
         print(f"  - {k8s_name}-pmtiles.yaml")
         print(f"  - {k8s_name}-hex.yaml")
         print(f"  - {k8s_name}-repartition.yaml")
-        print(f"  - workflow-rbac.yaml (generic, reusable)")
-        print(f"  - configmap.yaml (job configs)")
-        print(f"  - workflow.yaml (orchestrator)")
-        print(f"\nTo run:")
-        print(f"  # One-time RBAC setup")
+        print("  - workflow-rbac.yaml (generic, reusable)")
+        print("  - configmap.yaml (job configs)")
+        print("  - workflow.yaml (orchestrator)")
+        print("\nTo run:")
+        print("  # One-time RBAC setup")
         print(f"  kubectl apply -f {output_dir}/workflow-rbac.yaml")
-        print(f"")
-        print(f"  # Apply all workflow files (safe to re-run)")
+        print("")
+        print("  # Apply all workflow files (safe to re-run)")
         print(f"  kubectl apply -f {output_dir}/configmap.yaml")
         print(f"  kubectl apply -f {output_dir}/workflow.yaml")
-        print(f"")
-        print(f"  # Monitor progress")
+        print("")
+        print("  # Monitor progress")
         print(f"  kubectl logs -f job/{k8s_name}-workflow")
-        print(f"")
-        print(f"  # Clean up")
+        print("")
+        print("  # Clean up")
         print(f"  kubectl delete -f {output_dir}/workflow.yaml")
         print(f"  kubectl delete -f {output_dir}/configmap.yaml")
 
@@ -718,7 +718,7 @@ def generate_raster_workflow(
     if not needs_preprocess:
         from cng_datasets.raster.cog import is_cog
         if not is_cog(source_urls[0]):
-            print(f"  ⚠ Source raster is not a COG — adding preprocess-cog step to convert before hex tiling")
+            print("  ⚠ Source raster is not a COG — adding preprocess-cog step to convert before hex tiling")
             needs_preprocess = True
 
     if needs_preprocess:
@@ -776,14 +776,14 @@ def generate_raster_workflow(
         print(f"\nArmada files created in {output_dir}:")
         for f in armada_files:
             print(f"  - {Path(f).name}")
-        print(f"\nTo run (submit each step in order):")
+        print("\nTo run (submit each step in order):")
         steps = ["setup-bucket"]
         if needs_preprocess:
             steps.append("preprocess-cog")
         steps.append("hex")
         for step in steps:
             print(f"  armadactl submit {output_dir}/armada-{k8s_name}-{step}.yaml")
-        print(f"\nMonitor at: https://armada-lookout.nrp-nautilus.io")
+        print("\nMonitor at: https://armada-lookout.nrp-nautilus.io")
     else:
         print(f"\n✓ Generated raster workflow for {dataset_name}")
         print(f"\nFiles created in {output_dir}:")
@@ -791,10 +791,10 @@ def generate_raster_workflow(
         if needs_preprocess:
             print(f"  - {k8s_name}-preprocess-cog.yaml  (mosaic {len(source_urls)} tiles → {cog_key})")
         print(f"  - {k8s_name}-hex.yaml")
-        print(f"  - workflow-rbac.yaml")
-        print(f"  - configmap.yaml")
-        print(f"  - workflow.yaml")
-        print(f"\nTo run:")
+        print("  - workflow-rbac.yaml")
+        print("  - configmap.yaml")
+        print("  - workflow.yaml")
+        print("\nTo run:")
         print(f"  kubectl apply -f {output_dir}/workflow-rbac.yaml  # one-time")
         print(f"  kubectl apply -f {output_dir}/configmap.yaml -f {output_dir}/workflow.yaml")
 
@@ -913,7 +913,7 @@ if [ -n "$PROJ_DB" ]; then
 fi
 
 {cng_cmd}"""
-    
+
     pod_spec = {
         "restartPolicy": "Never",
         "containers": [{
@@ -1135,10 +1135,10 @@ def _generate_convert_job(manager, dataset_name, source_urls, bucket, output_pat
     # Normalize to list
     if isinstance(source_urls, str):
         source_urls = [source_urls]
-    
+
     # Build source URLs string (one per line for readability)
     sources_str = " \\\n  ".join(source_urls)
-    
+
     # Build the conversion command with optional layer parameter
     layer_flag = f" \\\n  --layer {layer}" if layer else ""
     convert_cmd = f"""set -e
@@ -1147,7 +1147,7 @@ cng-convert-to-parquet \\
   s3://{bucket}/{s3_dataset}.parquet \\
   --row-group-size {row_group_size}{layer_flag}
 """
-    
+
     pod_spec = {
         "restartPolicy": "Never",
         "containers": [{
@@ -1202,7 +1202,7 @@ def _generate_pmtiles_job(manager, dataset_name, source_url, bucket, output_path
     s3_dataset = s3_dataset or dataset_name
     # Use the converted geoparquet instead of original source
     geoparquet_url = f"https://{config.s3_public_endpoint}/{bucket}/{s3_dataset}.parquet"
-    
+
     # For rclone upload, compute the S3 directory that contains the output file
     if '/' in s3_dataset:
         s3_parent_dir = '/'.join(s3_dataset.split('/')[:-1]) + '/'
@@ -1210,7 +1210,7 @@ def _generate_pmtiles_job(manager, dataset_name, source_url, bucket, output_path
         s3_parent_dir = ''
     # basename for temp files and tippecanoe layer name
     s3_basename = s3_dataset.split('/')[-1]
-    
+
     pod_spec = {
         "restartPolicy": "Never",
         "containers": [{
@@ -1275,7 +1275,7 @@ rm /tmp/$DATASET.geojsonl /tmp/$DATASET.pmtiles
 
 def _generate_hex_job(manager, dataset_name, bucket, output_path, git_repo, chunk_size, completions, parallelism, h3_resolution, parent_resolutions, id_column=None, hex_memory="8Gi", intermediate_chunk_size=10, s3_dataset=None, hex_storage="10Gi", config: ClusterConfig = None):
     """Generate H3 hex tiling job.
-    
+
     Args:
         manager: K8sJobManager instance
         dataset_name: Name for k8s resources
@@ -1297,7 +1297,7 @@ def _generate_hex_job(manager, dataset_name, bucket, output_path, git_repo, chun
     s3_dataset = s3_dataset or dataset_name
     # Format parent resolutions as comma-separated string
     parent_res_str = ','.join(map(str, parent_resolutions))
-    
+
     # Build command with optional id-column parameter
     cmd_parts = [
         "set -e",
@@ -1305,9 +1305,9 @@ def _generate_hex_job(manager, dataset_name, bucket, output_path, git_repo, chun
     ]
     if id_column:
         cmd_parts[-1] += f" --id-column {id_column}"
-    
+
     command_str = "\n".join(cmd_parts)
-    
+
     pod_spec = {
         "restartPolicy": "Never",
         "containers": [{
@@ -1426,7 +1426,7 @@ cng-datasets repartition --chunks-dir s3://{bucket}/{s3_dataset}/chunks --output
 def _generate_workflow_rbac(namespace, output_path):
     """Generate generic workflow RBAC configuration for cng-datasets package."""
     import yaml
-    
+
     rbac = {
         "apiVersion": "v1",
         "kind": "ServiceAccount",
@@ -1435,7 +1435,7 @@ def _generate_workflow_rbac(namespace, output_path):
             "namespace": namespace
         }
     }
-    
+
     with open(output_path / "workflow-rbac.yaml", "w") as f:
         yaml.dump_all([
             rbac,
@@ -1460,25 +1460,25 @@ def _generate_workflow_rbac(namespace, output_path):
 
 def _generate_configmap(dataset_name, namespace, output_path, gen_command):
     """Generate ConfigMap YAML containing all job definitions.
-    
+
     Args:
         dataset_name: Sanitized k8s-compatible dataset name
-        namespace: Kubernetes namespace  
+        namespace: Kubernetes namespace
         output_path: Path object where YAML files are written
         gen_command: Command used to generate this workflow
     """
     import yaml
-    
+
     # Read all job YAML files
     job_files = [f"{dataset_name}-setup-bucket.yaml", f"{dataset_name}-convert.yaml", f"{dataset_name}-pmtiles.yaml", f"{dataset_name}-hex.yaml", f"{dataset_name}-repartition.yaml"]
     data = {}
-    
+
     for job_file in job_files:
         file_path = output_path / job_file
         if file_path.exists():
             with open(file_path, 'r') as f:
                 data[job_file] = f.read()
-    
+
     configmap = {
         "apiVersion": "v1",
         "kind": "ConfigMap",
@@ -1488,7 +1488,7 @@ def _generate_configmap(dataset_name, namespace, output_path, gen_command):
         },
         "data": data
     }
-    
+
     with open(output_path / "configmap.yaml", "w") as f:
         f.write("# Auto-generated ConfigMap containing job definitions\n")
         f.write(f"# Generated from: {dataset_name}-setup-bucket.yaml, {dataset_name}-convert.yaml, {dataset_name}-pmtiles.yaml, {dataset_name}-hex.yaml, {dataset_name}-repartition.yaml\n")
@@ -1508,7 +1508,7 @@ def _generate_configmap(dataset_name, namespace, output_path, gen_command):
 
 def _generate_argo_workflow(dataset_name, namespace, output_path, output_dir):
     """Generate K8s Job that orchestrates the workflow using a ConfigMap.
-    
+
     Args:
         dataset_name: Sanitized k8s-compatible dataset name (with hyphens)
         namespace: Kubernetes namespace
@@ -1516,9 +1516,9 @@ def _generate_argo_workflow(dataset_name, namespace, output_path, output_dir):
         output_dir: String path to YAML directory for kubectl create configmap command
     """
     import yaml
-    
+
     configmap_name = f"{dataset_name}-yamls"
-    
+
     workflow_job = {
         "apiVersion": "batch/v1",
         "kind": "Job",
@@ -1591,7 +1591,7 @@ echo "  kubectl delete configmap {configmap_name} -n {namespace}"
             "ttlSecondsAfterFinished": 10800
         }
     }
-    
+
     with open(output_path / "workflow.yaml", "w") as f:
         yaml.dump(workflow_job, f, default_flow_style=False)
 
@@ -1609,7 +1609,7 @@ def generate_sync_job(
 ) -> str:
     """
     Generate Kubernetes job for syncing between two S3 storage locations using rclone.
-    
+
     Args:
         job_name: Name for the Kubernetes job
         source: Source path in rclone remote format (e.g., 'remote1:bucket/path')
@@ -1620,10 +1620,10 @@ def generate_sync_job(
         cpu: CPU request/limit (default: 2)
         memory: Memory request/limit (default: 4Gi)
         dry_run: If True, only show what would be synced without actually syncing
-        
+
     Returns:
         Path to the generated YAML file
-        
+
     Example:
         >>> generate_sync_job(
         ...     job_name="sync-data",
@@ -1633,7 +1633,7 @@ def generate_sync_job(
         ... )
     """
     dry_run_flag = "--dry-run" if dry_run else ""
-    
+
     job_spec = {
         "apiVersion": "batch/v1",
         "kind": "Job",
@@ -1704,32 +1704,32 @@ rclone size "{destination}"
             }
         }
     }
-    
+
     # Save to file with custom representer for multiline strings
     output_path = Path(output_file)
     output_path.parent.mkdir(parents=True, exist_ok=True)
-    
+
     # Custom representer for multi-line strings to use literal style (|)
     def str_representer(dumper, data):
         if '\n' in data:
             return dumper.represent_scalar('tag:yaml.org,2002:str', data, style='|')
         return dumper.represent_scalar('tag:yaml.org,2002:str', data)
-    
+
     yaml.add_representer(str, str_representer)
-    
+
     with open(output_path, "w") as f:
         yaml.dump(job_spec, f, default_flow_style=False, sort_keys=False)
-    
+
     print(f"✓ Generated sync job: {output_file}")
-    print(f"")
-    print(f"Submit with:")
+    print("")
+    print("Submit with:")
     print(f"  kubectl apply -f {output_file} -n {namespace}")
-    print(f"")
-    print(f"Monitor progress:")
+    print("")
+    print("Monitor progress:")
     print(f"  kubectl logs -f job/{job_name} -n {namespace}")
-    print(f"")
-    print(f"Clean up:")
+    print("")
+    print("Clean up:")
     print(f"  kubectl delete -f {output_file} -n {namespace}")
-    
+
     return str(output_path)
 

--- a/cng_datasets/raster/cog.py
+++ b/cng_datasets/raster/cog.py
@@ -5,7 +5,7 @@ Tools for converting raster datasets to COG format and subsequently
 to H3-indexed parquet files partitioned by h0 cells.
 """
 
-from typing import Optional, Dict, Any, List, Union
+from typing import Optional, Dict, List, Union
 import os
 import math
 import tempfile
@@ -266,12 +266,12 @@ def _h3_res_to_degrees(h3_resolution: int) -> float:
 
 def _ensure_vsi_path(path: str, use_public_endpoint: bool = False) -> str:
     """Convert path to appropriate GDAL VSI notation.
-    
+
     Args:
         path: Input path (s3://, https://, or local)
         use_public_endpoint: If True, convert s3:// to /vsicurl/ with public HTTPS URL
                             for single-file reads (faster for public data)
-    
+
     Returns:
         Path in GDAL VSI notation
     """
@@ -403,11 +403,11 @@ def is_cog(url: str) -> bool:
 def detect_nodata_value(raster_path: str, verbose: bool = True) -> Optional[float]:
     """
     Detect NoData value from raster metadata.
-    
+
     Args:
         raster_path: Path to raster file (can be /vsis3/ URL)
         verbose: Whether to print detection message (default: True)
-        
+
     Returns:
         NoData value if found, None otherwise
     """
@@ -416,35 +416,35 @@ def detect_nodata_value(raster_path: str, verbose: bool = True) -> Optional[floa
     ds = gdal.Open(raster_path)
     if ds is None:
         raise ValueError(f"Could not open raster: {raster_path}")
-    
+
     # Get the first band
     band = ds.GetRasterBand(1)
     nodata_value = band.GetNoDataValue()
-    
+
     ds = None
-    
+
     if nodata_value is not None and verbose:
         print(f"✓ Auto-detected NoData value: {nodata_value}")
     elif verbose:
         print("ℹ No NoData value found in raster metadata")
-    
+
     return nodata_value
 
 
 def detect_optimal_h3_resolution(raster_path: str, verbose: bool = True) -> int:
     """
     Detect optimal H3 resolution based on raster resolution.
-    
+
     Uses the finest pixel dimension to recommend an H3 resolution.
     H3 average edge lengths (from https://h3geo.org/docs/core-library/restable):
     - h15: 0.58m, h14: 1.5m, h13: 4.1m, h12: 10.8m, h11: 28.7m
     - h10: 75.9m, h9: 200.8m, h8: 531.4m, h7: 1.4km, h6: 3.7km
     - h5: 9.9km, h4: 26.1km, h3: 69.0km, h2: 182.5km, h1: 483.1km, h0: 1281.3km
-    
+
     Args:
         raster_path: Path to raster file (can be /vsis3/ URL)
         verbose: Whether to print detection message (default: True)
-        
+
     Returns:
         Recommended H3 resolution (0-15)
     """
@@ -453,24 +453,24 @@ def detect_optimal_h3_resolution(raster_path: str, verbose: bool = True) -> int:
     ds = gdal.Open(raster_path)
     if ds is None:
         raise ValueError(f"Could not open raster: {raster_path}")
-    
+
     # Get geotransform to compute resolution
     gt = ds.GetGeoTransform()
     pixel_width = abs(gt[1])
     pixel_height = abs(gt[5])
-    
+
     # Use finest resolution
     pixel_res_deg = min(pixel_width, pixel_height)
-    
+
     # Convert to meters (approximate at equator: 1 degree ≈ 111km)
     pixel_res_m = pixel_res_deg * 111000
-    
+
     ds = None
-    
+
     # Map to H3 resolution
     # Use ~3x pixel resolution as target H3 edge length
     target_edge_m = pixel_res_m * 3
-    
+
     # H3 average edge lengths in Km (from https://h3geo.org/docs/core-library/restable/)
     # Converting to meters for comparison
     h3_edge_lengths_km = {
@@ -480,17 +480,17 @@ def detect_optimal_h3_resolution(raster_path: str, verbose: bool = True) -> int:
         12: 0.010830188, 13: 0.004092010, 14: 0.001546100, 15: 0.000584169
     }
     h3_edge_lengths = {res: km * 1000 for res, km in h3_edge_lengths_km.items()}
-    
+
     # Find closest H3 resolution
     best_res = 8  # default
     min_diff = float('inf')
-    
+
     for res, edge_m in h3_edge_lengths.items():
         diff = abs(math.log10(edge_m) - math.log10(target_edge_m))
         if diff < min_diff:
             min_diff = diff
             best_res = res
-    
+
     if verbose:
         print(f"Raster resolution: {pixel_res_m:.1f}m → Recommended H3: {best_res}")
     return best_res
@@ -613,7 +613,7 @@ def create_mosaic_cog(
         # Writing directly to COG via auto-overview generation is unreliable for S3
         # output and for large files; the explicit BuildOverviews + COPY_SRC_OVERVIEWS
         # pattern is the recommended approach for fast GDAL downsampling (issue #25).
-        print(f"  Writing intermediate GTiff...")
+        print("  Writing intermediate GTiff...")
         tmp_tif = os.path.join(workdir, "intermediate.tif")
         tmp_opts = gdal.TranslateOptions(
             format="GTiff",
@@ -624,7 +624,7 @@ def create_mosaic_cog(
             raise RuntimeError(f"gdal.Translate (GTiff) failed: {gdal.GetLastErrorMsg()}")
         result = None
 
-        print(f"  Building overviews...")
+        print("  Building overviews...")
         tmp_ds = gdal.Open(tmp_tif, gdal.GA_Update)
         tmp_ds.BuildOverviews("AVERAGE", [2, 4, 8, 16, 32, 64])
         tmp_ds = None
@@ -661,12 +661,12 @@ def create_mosaic_cog(
 class RasterProcessor:
     """
     Process raster datasets into cloud-native formats.
-    
+
     Converts raster data to COG format and H3-indexed parquet files
     partitioned by h0 cells, processing each h0 region separately
     for memory efficiency with global datasets.
     """
-    
+
     def __init__(
         self,
         input_path: Union[str, List[str]],
@@ -827,7 +827,7 @@ class RasterProcessor:
         self.hex_resampling = hex_resampling
         self.read_credentials = read_credentials
         self.write_credentials = write_credentials
-        
+
         # Auto-detect NoData value if not specified
         if nodata_value is None:
             detected_nodata = detect_nodata_value(input_path, verbose=True)
@@ -839,10 +839,10 @@ class RasterProcessor:
         else:
             self.nodata_value = nodata_value
             print(f"✓ Using user-specified NoData value: {nodata_value}")
-        
+
         # Handle H3 resolution with informative messages
         detected_resolution = detect_optimal_h3_resolution(input_path, verbose=False)
-        
+
         if h3_resolution is None:
             # Use auto-detected resolution
             self.h3_resolution = detected_resolution
@@ -850,43 +850,43 @@ class RasterProcessor:
         else:
             # User specified a resolution - compare with detection
             self.h3_resolution = h3_resolution
-            
+
             if h3_resolution != detected_resolution:
                 if h3_resolution < detected_resolution:
                     print(f"ℹ Using coarser resolution h{h3_resolution} (user specified) instead of detected h{detected_resolution}")
-                    print(f"  Note: Coarser resolution will aggregate more pixels per H3 cell")
+                    print("  Note: Coarser resolution will aggregate more pixels per H3 cell")
                 else:
                     print(f"ℹ Using finer resolution h{h3_resolution} (user specified) instead of detected h{detected_resolution}")
-                    print(f"  Note: Finer resolution will create more H3 cells and larger output files")
+                    print("  Note: Finer resolution will create more H3 cells and larger output files")
             else:
                 print(f"✓ Using h{h3_resolution} (matches auto-detected resolution)")
-        
+
         self.parent_resolutions = parent_resolutions or []
-        
+
         # Set up DuckDB connection
         self.con = self._setup_duckdb()
 
         # Pre-compute source raster bounds in EPSG:4326 for fast h0 intersection checks
         self._src_bounds_4326 = self._compute_src_bounds_4326()
-    
+
     def _setup_duckdb(self) -> duckdb.DuckDBPyConnection:
         """Set up DuckDB connection with extensions."""
         con = duckdb.connect()
-        
+
         # Install and load extensions
         con.execute("INSTALL spatial")
         con.execute("LOAD spatial")
         con.execute("INSTALL h3 FROM community")
         con.execute("LOAD h3")
-        
+
         # Configure HTTP settings
         con.execute("SET http_retries=20")
         con.execute("SET http_retry_wait_ms=5000")
         con.execute("SET temp_directory='/tmp'")
-        
+
         # Configure S3 credentials
         configure_s3_credentials(con)
-        
+
         return con
 
     def _compute_src_bounds_4326(self) -> tuple:
@@ -929,27 +929,27 @@ class RasterProcessor:
     ) -> str:
         """
         Create a Cloud-Optimized GeoTIFF from input raster.
-        
+
         Optimized for cloud rendering in services like titiler with:
         - Internal tiling
         - Overview pyramids
         - Optimized compression
         - EPSG:4326 reprojection
-        
+
         Args:
             output_path: Path for output COG (uses self.output_cog_path if None)
             overviews: Whether to create overview pyramids
             overview_resampling: Resampling method for overviews
-            
+
         Returns:
             Path to created COG file
         """
         if output_path is None:
             output_path = self.output_cog_path
-        
+
         if output_path is None:
             raise ValueError("output_path or output_cog_path must be specified")
-        
+
         print(f"Creating COG: {output_path}")
         print(f"  Input: {self.input_path}")
 
@@ -1003,7 +1003,7 @@ class RasterProcessor:
                 cog_creation_opts.append('COPY_SRC_OVERVIEWS=YES')
                 cog_creation_opts.append(f'OVERVIEW_RESAMPLING={overview_resampling.upper()}')
 
-            print(f"  Writing COG...")
+            print("  Writing COG...")
             vsi_output = _ensure_vsi_path(output_path)
             # COG driver requires random-write access; /vsis3/ needs this config option.
             if vsi_output.startswith("/vsis3/"):
@@ -1022,7 +1022,7 @@ class RasterProcessor:
             raise RuntimeError(f"Failed to create COG: {gdal.GetLastErrorMsg()}")
 
         result = None  # Close dataset
-        
+
         print(f"  ✓ COG created: {output_path}")
         return output_path
 
@@ -1225,32 +1225,32 @@ class RasterProcessor:
         Polyfills the h0 cell to its native-resolution H3 children and
         area-weighted-aggregates source-raster values into each cell via
         exactextract. Parent resolutions are added as decoration columns.
-        
+
         Args:
             h0_index: h0 cell index (0-121), uses self.h0_index if None
-            
+
         Returns:
             Path to output parquet file, or None if region has no data
         """
         if h0_index is None:
             h0_index = self.h0_index
-        
+
         if h0_index is None:
             raise ValueError("h0_index must be specified")
-        
+
         print(f"\nProcessing h0 region {h0_index}...")
-        
+
         # Load h0 polygons to get the geometry using SQL with ST_AsText for WKT
         h0_result = self.con.execute(f"""
             SELECT h0, ST_AsText(geom) as geom_wkt
             FROM read_parquet('{self.h0_grid_path}')
             WHERE i = {h0_index}
         """).fetchdf()
-        
+
         if len(h0_result) == 0:
             print(f"  ⚠ No h0 region found for index {h0_index}")
             return None
-            
+
         h0_geom_wkt = h0_result['geom_wkt'].iloc[0]
         h0_cell = h0_result['h0'].iloc[0]
 
@@ -1337,7 +1337,7 @@ class RasterProcessor:
         result = None
 
         try:
-            print(f"  warp-centroid: converting XYZ → H3...")
+            print("  warp-centroid: converting XYZ → H3...")
 
             # Bound to a local so DuckDB's replacement scan resolves the
             # `FROM xyz_table` reference in the COPY below (looks unused to
@@ -1389,12 +1389,12 @@ class RasterProcessor:
     def process_all_h0_regions(self) -> List[str]:
         """
         Process all h0 regions (0-121) to H3-indexed parquet.
-        
+
         Returns:
             List of output parquet file paths
         """
         output_files = []
-        
+
         for h0_index in range(122):
             try:
                 output_file = self.process_h0_region(h0_index)
@@ -1402,7 +1402,7 @@ class RasterProcessor:
                     output_files.append(output_file)
             except Exception as e:
                 print(f"  ✗ Error processing h0 {h0_index}: {e}")
-        
+
         print(f"\n✓ Processed {len(output_files)} h0 regions")
         return output_files
 
@@ -1418,9 +1418,9 @@ def create_cog(
 ) -> str:
     """
     Create a Cloud-Optimized GeoTIFF.
-    
+
     Convenience function that wraps RasterProcessor.create_cog().
-    
+
     Args:
         input_path: Path to input raster file
         output_path: Path for output COG file
@@ -1429,7 +1429,7 @@ def create_cog(
         overviews: Whether to create overview pyramids
         resampling: Resampling method
         **kwargs: Additional arguments passed to RasterProcessor
-        
+
     Returns:
         Path to created COG file
     """
@@ -1441,5 +1441,5 @@ def create_cog(
         resampling=resampling,
         **kwargs
     )
-    
+
     return processor.create_cog()

--- a/cng_datasets/storage/__init__.py
+++ b/cng_datasets/storage/__init__.py
@@ -5,9 +5,9 @@ from .rclone import RcloneSync, create_public_bucket as create_public_bucket_rcl
 from .setup_bucket import setup_public_bucket
 
 __all__ = [
-    "S3Manager", 
-    "configure_bucket_cors", 
-    "create_public_bucket", 
+    "S3Manager",
+    "configure_bucket_cors",
+    "create_public_bucket",
     "RcloneSync",
     "create_public_bucket_rclone",
     "setup_public_bucket"

--- a/cng_datasets/storage/rclone.py
+++ b/cng_datasets/storage/rclone.py
@@ -5,7 +5,7 @@ Tools for syncing datasets across multiple S3-compatible storage providers
 using rclone.
 """
 
-from typing import Optional, List, Dict
+from typing import Optional, List
 import subprocess
 import os
 from pathlib import Path
@@ -18,12 +18,12 @@ def create_public_bucket(
 ) -> bool:
     """
     Create a public bucket with rclone and set it to public read access.
-    
+
     Args:
         bucket_name: Name of the bucket to create
         remote: Rclone remote name (default: nrp)
         set_cors: Whether to set CORS headers (default: True)
-        
+
     Returns:
         True if successful, False otherwise
     """
@@ -36,14 +36,14 @@ def create_public_bucket(
             text=True,
             check=False
         )
-        
+
         if result.returncode != 0 and "already exists" not in result.stderr.lower():
             print(f"Error creating bucket: {result.stderr}")
             return False
-        
+
         # Set public read policy using AWS CLI
         endpoint = os.getenv("AWS_PUBLIC_ENDPOINT", "s3-west.nrp-nautilus.io")
-        
+
         print(f"Setting public read access for bucket: {bucket_name}")
         policy = {
             "Version": "2012-10-17",
@@ -65,13 +65,13 @@ def create_public_bucket(
                 }
             ]
         }
-        
+
         import json
         policy_json = json.dumps(policy)
-        
+
         # Build environment with AWS credentials explicitly
         env = os.environ.copy()
-        
+
         result = subprocess.run(
             [
                 "aws", "s3api", "put-bucket-policy",
@@ -84,12 +84,12 @@ def create_public_bucket(
             check=False,
             env=env
         )
-        
+
         if result.returncode != 0:
             print(f"Warning: Could not set public policy: {result.stderr}")
         else:
             print(f"✓ Public read access enabled for bucket: {bucket_name}")
-        
+
         # Set CORS if requested
         if set_cors:
             print(f"Setting CORS configuration for bucket: {bucket_name}")
@@ -102,9 +102,9 @@ def create_public_bucket(
                     "MaxAgeSeconds": 3600
                 }]
             }
-            
+
             cors_json = json.dumps(cors_config)
-            
+
             result = subprocess.run(
                 [
                     "aws", "s3api", "put-bucket-cors",
@@ -117,14 +117,14 @@ def create_public_bucket(
                 check=False,
                 env=os.environ.copy()
             )
-            
+
             if result.returncode != 0:
                 print(f"Warning: Could not set CORS: {result.stderr}")
             else:
                 print(f"✓ CORS configuration set for bucket: {bucket_name}")
-        
+
         return True
-        
+
     except Exception as e:
         print(f"Error creating public bucket: {e}")
         return False
@@ -133,10 +133,10 @@ def create_public_bucket(
 class RcloneSync:
     """
     Manage rclone synchronization of datasets.
-    
+
     Handles syncing between different S3-compatible storage providers.
     """
-    
+
     def __init__(
         self,
         config_path: Optional[str] = None,
@@ -144,14 +144,14 @@ class RcloneSync:
     ):
         """
         Initialize rclone sync manager.
-        
+
         Args:
             config_path: Path to rclone config file
             dry_run: If True, only simulate sync operations
         """
         self.config_path = config_path or str(Path.home() / ".config" / "rclone" / "rclone.conf")
         self.dry_run = dry_run
-    
+
     def sync(
         self,
         source: str,
@@ -161,13 +161,13 @@ class RcloneSync:
     ) -> subprocess.CompletedProcess:
         """
         Sync files from source to destination.
-        
+
         Args:
             source: Source path (remote:bucket/path or local path)
             destination: Destination path (remote:bucket/path or local path)
             filters: List of filter patterns (--include, --exclude)
             flags: Additional rclone flags
-            
+
         Returns:
             Completed process result
         """
@@ -177,21 +177,21 @@ class RcloneSync:
             "--progress",
             "--checksum",
         ]
-        
+
         if self.dry_run:
             cmd.append("--dry-run")
-        
+
         if filters:
             cmd.extend(filters)
-        
+
         if flags:
             cmd.extend(flags)
-        
+
         cmd.extend([source, destination])
-        
+
         print(f"Running: {' '.join(cmd)}")
         return subprocess.run(cmd, capture_output=True, text=True)
-    
+
     def copy(
         self,
         source: str,
@@ -200,18 +200,18 @@ class RcloneSync:
     ) -> subprocess.CompletedProcess:
         """
         Copy files from source to destination (doesn't delete from destination).
-        
+
         Args:
             source: Source path
             destination: Destination path
             **kwargs: Additional arguments passed to sync
-            
+
         Returns:
             Completed process result
         """
         # Similar to sync but uses 'copy' command
         raise NotImplementedError("Copy operation to be implemented")
-    
+
     def configure_remote(
         self,
         remote_name: str,
@@ -223,7 +223,7 @@ class RcloneSync:
     ):
         """
         Configure a new rclone remote.
-        
+
         Args:
             remote_name: Name for the remote
             provider: Provider type (s3, aws, cloudflare, etc.)
@@ -245,7 +245,7 @@ def sync_to_providers(
 ):
     """
     Sync a dataset from source to multiple target providers.
-    
+
     Args:
         source_bucket: Source bucket name
         source_remote: Source rclone remote name
@@ -254,19 +254,19 @@ def sync_to_providers(
         **kwargs: Additional arguments passed to RcloneSync
     """
     syncer = RcloneSync(**kwargs)
-    
+
     source_path = f"{source_remote}:{source_bucket}"
     if path:
         source_path += f"/{path}"
-    
+
     results = []
     for target_remote in target_remotes:
         target_path = f"{target_remote}:{source_bucket}"
         if path:
             target_path += f"/{path}"
-        
+
         print(f"\nSyncing to {target_remote}...")
         result = syncer.sync(source_path, target_path)
         results.append((target_remote, result))
-    
+
     return results

--- a/cng_datasets/storage/s3.py
+++ b/cng_datasets/storage/s3.py
@@ -5,16 +5,15 @@ Tools for creating, configuring, and managing S3 buckets for
 public dataset distribution.
 """
 
-from typing import Optional, Dict, Any, List
+from typing import Optional, List
 import json
 import os
-import duckdb
 
 
 def configure_s3_credentials(con) -> None:
     """
     Configure S3 credentials for DuckDB using environment variables.
-    
+
     Args:
         con: DuckDB connection (raw or ibis) to configure
     """
@@ -28,26 +27,26 @@ def configure_s3_credentials(con) -> None:
         # Raw DuckDB connection
         con.execute("INSTALL httpfs")
         con.execute("LOAD httpfs")
-    
+
     # Enable large buffer size for complex geometries
     if hasattr(con, 'raw_sql'):
         con.raw_sql("SET arrow_large_buffer_size=true")
     else:
         con.execute("SET arrow_large_buffer_size=true")
-    
+
     key = os.getenv("AWS_ACCESS_KEY_ID", "")
     secret = os.getenv("AWS_SECRET_ACCESS_KEY", "")
     endpoint = os.getenv("AWS_S3_ENDPOINT", "s3-west.nrp-nautilus.io")
     region = os.getenv("AWS_REGION", "us-east-1")
     use_ssl = os.getenv("AWS_HTTPS", "TRUE")
     url_style = os.getenv("AWS_VIRTUAL_HOSTING", "FALSE")
-    
+
     # Convert TRUE/FALSE strings to path/vhost
     if url_style.upper() == "FALSE":
         url_style = "path"
     else:
         url_style = "vhost"
-    
+
     # Always create secret, even for anonymous/public access (empty key/secret)
     # USE_SSL must be a string, not boolean!
     query = f"""
@@ -70,10 +69,10 @@ def configure_s3_credentials(con) -> None:
 class S3Manager:
     """
     Manage S3 buckets for dataset storage.
-    
+
     Handles bucket creation, CORS configuration, and public access setup.
     """
-    
+
     def __init__(
         self,
         access_key: Optional[str] = None,
@@ -83,7 +82,7 @@ class S3Manager:
     ):
         """
         Initialize S3 manager.
-        
+
         Args:
             access_key: AWS access key ID
             secret_key: AWS secret access key
@@ -95,7 +94,7 @@ class S3Manager:
         self.endpoint_url = endpoint_url
         self.region = region
         self._client = None
-    
+
     @property
     def client(self):
         """Get or create boto3 S3 client."""
@@ -109,21 +108,21 @@ class S3Manager:
                 region_name=self.region,
             )
         return self._client
-    
+
     def create_bucket(self, bucket_name: str, public: bool = False) -> str:
         """
         Create an S3 bucket.
-        
+
         Args:
             bucket_name: Name for the bucket
             public: Whether to configure for public read access
-            
+
         Returns:
             Bucket name
         """
         # Placeholder - to be implemented with boto3
         raise NotImplementedError("Bucket creation to be implemented")
-    
+
     def configure_cors(
         self,
         bucket_name: str,
@@ -132,7 +131,7 @@ class S3Manager:
     ):
         """
         Configure CORS for a bucket.
-        
+
         Args:
             bucket_name: Bucket name
             allowed_origins: List of allowed origins (default: ["*"])
@@ -142,7 +141,7 @@ class S3Manager:
             allowed_origins = ["*"]
         if allowed_methods is None:
             allowed_methods = ["GET", "HEAD"]
-        
+
         cors_configuration = {
             'CORSRules': [{
                 'AllowedOrigins': allowed_origins,
@@ -151,17 +150,17 @@ class S3Manager:
                 'MaxAgeSeconds': 3600
             }]
         }
-        
+
         self.client.put_bucket_cors(
             Bucket=bucket_name,
             CORSConfiguration=cors_configuration
         )
         print(f"CORS configured for bucket: {bucket_name}")
-    
+
     def set_public_read(self, bucket_name: str):
         """
         Configure bucket for public read access.
-        
+
         Args:
             bucket_name: Bucket name
         """
@@ -175,7 +174,7 @@ class S3Manager:
                 "Resource": f"arn:aws:s3:::{bucket_name}/*"
             }]
         }
-        
+
         self.client.put_bucket_policy(
             Bucket=bucket_name,
             Policy=json.dumps(policy)
@@ -190,7 +189,7 @@ def configure_bucket_cors(
 ):
     """
     Convenience function to configure CORS for a bucket.
-    
+
     Args:
         bucket_name: Bucket name
         endpoint_url: S3-compatible endpoint URL
@@ -207,12 +206,12 @@ def create_public_bucket(
 ) -> str:
     """
     Create a publicly accessible S3 bucket.
-    
+
     Args:
         bucket_name: Name for the bucket
         endpoint_url: S3-compatible endpoint URL
         **kwargs: Additional arguments passed to S3Manager
-        
+
     Returns:
         Bucket name
     """

--- a/cng_datasets/storage/setup_bucket.py
+++ b/cng_datasets/storage/setup_bucket.py
@@ -21,22 +21,22 @@ def setup_public_bucket(
 ) -> bool:
     """
     Create and configure a public S3 bucket with proper permissions.
-    
+
     This function:
     1. Creates the bucket if it doesn't exist
     2. Sets public read policy (list bucket + get objects)
     3. Configures CORS headers for browser access
-    
+
     Args:
         bucket_name: Name of the bucket to create/configure
         remote: Rclone remote name (default: nrp)
         endpoint: S3 endpoint URL (defaults to AWS_PUBLIC_ENDPOINT env var)
         set_cors: Whether to configure CORS headers (default: True)
         verbose: Print detailed progress (default: True)
-        
+
     Returns:
         True if successful, False otherwise
-        
+
     Example:
         >>> setup_public_bucket("my-data-bucket")
         Creating bucket: my-data-bucket
@@ -48,17 +48,17 @@ def setup_public_bucket(
     # Get endpoint from environment if not specified
     if endpoint is None:
         endpoint = os.getenv("AWS_PUBLIC_ENDPOINT", "s3-west.nrp-nautilus.io")
-    
+
     # Ensure AWS credentials are set
     if not os.getenv("AWS_ACCESS_KEY_ID") or not os.getenv("AWS_SECRET_ACCESS_KEY"):
         print("ERROR: AWS_ACCESS_KEY_ID and AWS_SECRET_ACCESS_KEY must be set")
         return False
-    
+
     try:
         # Step 1: Create bucket using rclone
         if verbose:
             print(f"Creating bucket: {bucket_name}")
-        
+
         result = subprocess.run(
             ["rclone", "mkdir", f"{remote}:{bucket_name}"],
             capture_output=True,
@@ -66,21 +66,21 @@ def setup_public_bucket(
             check=False,
             env=os.environ.copy()
         )
-        
+
         if result.returncode != 0 and "already exists" not in result.stderr.lower():
             print(f"ERROR: Could not create bucket: {result.stderr}")
             return False
-        
+
         if verbose:
             if "already exists" in result.stderr.lower():
                 print(f"✓ Bucket already exists: {bucket_name}")
             else:
                 print(f"✓ Bucket created: {bucket_name}")
-        
+
         # Step 2: Set public read policy using AWS CLI
         if verbose:
             print(f"Setting public read access for bucket: {bucket_name}")
-        
+
         policy = {
             "Version": "2012-10-17",
             "Statement": [
@@ -101,12 +101,12 @@ def setup_public_bucket(
                 }
             ]
         }
-        
+
         policy_json = json.dumps(policy)
-        
+
         # Build environment with AWS credentials
         env = os.environ.copy()
-        
+
         result = subprocess.run(
             [
                 "aws", "s3api", "put-bucket-policy",
@@ -119,19 +119,19 @@ def setup_public_bucket(
             check=False,
             env=env
         )
-        
+
         if result.returncode != 0:
             print(f"ERROR: Could not set public policy: {result.stderr}")
             return False
-        
+
         if verbose:
             print(f"✓ Public read access enabled for bucket: {bucket_name}")
-        
+
         # Step 3: Set CORS configuration if requested
         if set_cors:
             if verbose:
                 print(f"Setting CORS configuration for bucket: {bucket_name}")
-            
+
             cors_config = {
                 "CORSRules": [{
                     "AllowedOrigins": ["*"],
@@ -141,9 +141,9 @@ def setup_public_bucket(
                     "MaxAgeSeconds": 3600
                 }]
             }
-            
+
             cors_json = json.dumps(cors_config)
-            
+
             result = subprocess.run(
                 [
                     "aws", "s3api", "put-bucket-cors",
@@ -156,19 +156,19 @@ def setup_public_bucket(
                 check=False,
                 env=env
             )
-            
+
             if result.returncode != 0:
                 print(f"ERROR: Could not set CORS: {result.stderr}")
                 return False
-            
+
             if verbose:
                 print(f"✓ CORS configuration set for bucket: {bucket_name}")
-        
+
         if verbose:
             print(f"\n✓ Bucket '{bucket_name}' is ready for public access")
-        
+
         return True
-        
+
     except Exception as e:
         print(f"ERROR: Failed to setup bucket: {e}")
         return False
@@ -177,17 +177,17 @@ def setup_public_bucket(
 def verify_bucket_config(bucket_name: str, endpoint: Optional[str] = None) -> dict:
     """
     Verify bucket configuration (policy and CORS).
-    
+
     Args:
         bucket_name: Bucket name to verify
         endpoint: S3 endpoint URL (defaults to AWS_PUBLIC_ENDPOINT env var)
-        
+
     Returns:
         Dict with verification results
     """
     if endpoint is None:
         endpoint = os.getenv("AWS_PUBLIC_ENDPOINT", "s3-west.nrp-nautilus.io")
-    
+
     env = os.environ.copy()
     results = {
         "bucket": bucket_name,
@@ -195,7 +195,7 @@ def verify_bucket_config(bucket_name: str, endpoint: Optional[str] = None) -> di
         "cors": None,
         "errors": []
     }
-    
+
     # Check policy
     result = subprocess.run(
         [
@@ -208,15 +208,15 @@ def verify_bucket_config(bucket_name: str, endpoint: Optional[str] = None) -> di
         check=False,
         env=env
     )
-    
+
     if result.returncode == 0:
         try:
             results["policy"] = json.loads(json.loads(result.stdout)["Policy"])
-        except:
+        except (ValueError, KeyError, TypeError):
             results["errors"].append(f"Could not parse policy: {result.stdout}")
     else:
         results["errors"].append(f"Could not get policy: {result.stderr}")
-    
+
     # Check CORS
     result = subprocess.run(
         [
@@ -229,41 +229,41 @@ def verify_bucket_config(bucket_name: str, endpoint: Optional[str] = None) -> di
         check=False,
         env=env
     )
-    
+
     if result.returncode == 0:
         try:
             results["cors"] = json.loads(result.stdout)
-        except:
+        except ValueError:
             results["errors"].append(f"Could not parse CORS: {result.stdout}")
     else:
         results["errors"].append(f"Could not get CORS: {result.stderr}")
-    
+
     return results
 
 
 def main():
     """CLI entry point for bucket setup."""
     import argparse
-    
+
     parser = argparse.ArgumentParser(
         description="Setup S3 bucket with public access and CORS",
         formatter_class=argparse.RawDescriptionHelpFormatter,
     )
-    
+
     parser.add_argument("bucket", help="Bucket name to setup")
     parser.add_argument("--remote", default="nrp", help="Rclone remote name (default: nrp)")
     parser.add_argument("--endpoint", help="S3 endpoint URL (default: AWS_PUBLIC_ENDPOINT env var)")
     parser.add_argument("--no-cors", action="store_true", help="Skip CORS configuration")
     parser.add_argument("--verify", action="store_true", help="Verify bucket configuration")
     parser.add_argument("--quiet", action="store_true", help="Minimal output")
-    
+
     args = parser.parse_args()
-    
+
     if args.verify:
         results = verify_bucket_config(args.bucket, args.endpoint)
         print(json.dumps(results, indent=2))
         return 0 if not results["errors"] else 1
-    
+
     success = setup_public_bucket(
         bucket_name=args.bucket,
         remote=args.remote,
@@ -271,7 +271,7 @@ def main():
         set_cors=not args.no_cors,
         verbose=not args.quiet
     )
-    
+
     return 0 if success else 1
 
 

--- a/cng_datasets/vector/convert_to_parquet.py
+++ b/cng_datasets/vector/convert_to_parquet.py
@@ -16,10 +16,8 @@ import sys
 import tempfile
 import os
 import shutil
-import glob
 import subprocess
 import zipfile
-from pathlib import Path
 from typing import Optional, Tuple, List, Union
 import duckdb
 import geopandas as gpd
@@ -133,11 +131,11 @@ def _linearize_source(source_url: str, layer: Optional[str] = None,
     """
     if not _is_gdb_source(source_url):
         if verbose:
-            print(f"  Source is not a GDB — skipping linearization")
+            print("  Source is not a GDB — skipping linearization")
         return source_url, layer, None
 
-    print(f"  GDB source detected — linearizing with ogr2ogr "
-          f"(CONVERT_TO_LINEAR + PROMOTE_TO_MULTI)...")
+    print("  GDB source detected — linearizing with ogr2ogr "
+          "(CONVERT_TO_LINEAR + PROMOTE_TO_MULTI)...")
 
     lin_dir = tempfile.mkdtemp(prefix='cng_linearize_')
     output_path = os.path.join(lin_dir, 'linearized.gpkg')
@@ -169,10 +167,10 @@ def _linearize_source(source_url: str, layer: Optional[str] = None,
 def is_parquet_file(source_url: str) -> bool:
     """
     Check if a source URL points to a parquet file.
-    
+
     Args:
         source_url: Source dataset URL
-        
+
     Returns:
         True if the file ends with .parquet, False otherwise
     """
@@ -185,7 +183,7 @@ def is_parquet_file(source_url: str) -> bool:
 def download_and_extract(url: str, extract_to: str, verbose: bool = False) -> None:
     """
     Download a file from a URL and extract it if it is a zip file.
-    
+
     Args:
         url: Source URL
         extract_to: Directory to extract to
@@ -194,21 +192,21 @@ def download_and_extract(url: str, extract_to: str, verbose: bool = False) -> No
     try:
         if verbose:
             print(f"  Downloading {url}...")
-            
+
         # Handle S3 URLs via https if possible, otherwise rely on system tools or direct download
         # For simplicity, if it's s3-west.nrp-nautilus.io, we can use requests/urllib
-        # If it's generic s3://, we might need boto3 or rclone? 
+        # If it's generic s3://, we might need boto3 or rclone?
         # For now, let's assume http/https or file path
-        
+
         local_zip = os.path.join(extract_to, "downloadpkg.zip")
-        
+
         if url.startswith("s3://"):
              # Simple S3 to https conversion for Nautilus
              if "nrp-nautilus.io" in url or "public-iucn" in url: # minimal heuristic
                  # This might need to be more robust, but complying with user request example
                  path = url.replace("s3://", "")
                  url = f"https://s3-west.nrp-nautilus.io/{path}"
-        
+
         if url.startswith(("http://", "https://")):
             urlretrieve(url, local_zip)
         else:
@@ -217,16 +215,16 @@ def download_and_extract(url: str, extract_to: str, verbose: bool = False) -> No
                 shutil.copy(url, local_zip)
             else:
                 raise ValueError(f"File not found: {url}")
-                
+
         if verbose:
-            print(f"  Extracting zip file...")
-            
+            print("  Extracting zip file...")
+
         with zipfile.ZipFile(local_zip, 'r') as zip_ref:
             zip_ref.extractall(extract_to)
-            
+
         # Cleanup zip
         os.remove(local_zip)
-        
+
     except Exception as e:
         raise RuntimeError(f"Failed to download/extract zip: {e}")
 
@@ -246,7 +244,7 @@ def find_shapefiles(directory: str) -> List[str]:
 def detect_crs(source_input: str, layer: Optional[str] = None, verbose: bool = False) -> Optional[str]:
     """
     Detect the CRS of a vector dataset using geopandas.
-    
+
     Args:
         source_input: Source dataset URL or path
         layer: Layer name
@@ -257,30 +255,30 @@ def detect_crs(source_input: str, layer: Optional[str] = None, verbose: bool = F
         kwargs = {'rows': 1}
         if layer:
             kwargs['layer'] = layer
-            
+
         # If source_input is a URL that geopandas can't handle directly without vsicurl, ensure it's handled
         # But for shapefiles on disk (which pass into here), it works fine.
-        
+
         gdf = gpd.read_file(source_input, **kwargs)
-        
+
         if gdf.crs is None:
             if verbose:
                 print("Warning: No CRS found in dataset")
             return None
-        
+
         # Try to get EPSG code
         if gdf.crs.to_epsg():
             return f"EPSG:{gdf.crs.to_epsg()}"
-        
+
         # Fallback to authority string if available
         if gdf.crs.to_authority():
             auth, code = gdf.crs.to_authority()
             return f"{auth}:{code}"
-        
+
         if verbose:
             print(f"Warning: Could not determine EPSG code, CRS is: {gdf.crs}")
         return None
-        
+
     except Exception as e:
         if verbose:
             print(f"Warning: CRS detection failed: {e}")
@@ -354,17 +352,17 @@ def get_geometry_column(source_url: str, layer: Optional[str] = None, verbose: b
 def is_geographic_crs(crs: str) -> bool:
     """
     Check if a CRS is geographic (uses degrees) vs projected (uses meters).
-    
+
     Args:
         crs: CRS string (e.g., "EPSG:4326")
-        
+
     Returns:
         True if geographic, False if projected
     """
     # Common geographic CRS codes
     if crs in ["EPSG:4326", "EPSG:4269", "EPSG:4267"]:
         return True
-    
+
     # Extract EPSG code
     if crs.startswith("EPSG:"):
         try:
@@ -374,7 +372,7 @@ def is_geographic_crs(crs: str) -> bool:
                 return True
         except (ValueError, IndexError):
             pass
-    
+
     return False
 
 
@@ -475,13 +473,13 @@ def build_read_reproject_query(source_inputs: Union[str, List[str]], source_crs:
     else:
         # No reprojection needed; DuckDB ST_Read returns (lon, lat) for all formats
         geom_expr = f"{raw_geom} AS {geom_col}" if geom_is_blob else geom_col
-    
+
     layer_param = f", layer='{layer}'" if layer else ""
-    
+
     # helper to format a single SELECT
     def make_select(src):
         return f"""
-        SELECT 
+        SELECT
             * EXCLUDE ({geom_col}),
             {geom_expr}
         FROM ST_Read('{src}'{layer_param})
@@ -493,26 +491,26 @@ def build_read_reproject_query(source_inputs: Union[str, List[str]], source_crs:
         query = "\nUNION ALL\n".join(selects)
     else:
         query = make_select(source_inputs)
-    
+
     if verbose:
         print(f"Read/Reproject Query (preview): {query[:500]}...")
-    
+
     return query
 
 
 def add_id_column_query(base_query: str, id_column: str = "_cng_fid") -> str:
     """
     Wrap a query to add a synthetic ID column.
-    
+
     Args:
         base_query: Base query that reads/reprojects data
         id_column: Name of ID column to create
-        
+
     Returns:
         Wrapped query with ID column
     """
     return f"""
-    SELECT 
+    SELECT
         ROW_NUMBER() OVER () AS {id_column},
         *
     FROM ({base_query})
@@ -533,11 +531,11 @@ def process_parquet_input(
 ):
     """
     Process a parquet input file to ensure it has global ID and cloud optimization.
-    
+
     When the input is already parquet, we use DuckDB to read it directly
     without using ST_Read, ensuring we have an ID column and applying
     GeoParquet optimizations.
-    
+
     Args:
         source_url: Source parquet URL (supports s3://, http://, file paths)
         destination: Output path (s3:// or local file path)
@@ -552,18 +550,18 @@ def process_parquet_input(
     """
     print(f"Processing parquet file: {source_url}")
     print(f"               Output to: {destination}")
-    
+
     if progress:
         print(f"  Compression: {compression} level {compression_level}")
         print(f"  Row group size: {row_group_size:,}")
-    
+
     con = duckdb.connect(':memory:')
     con.install_extension("spatial")
     con.load_extension("spatial")
-    
+
     # Enable large buffer size for complex geometries
     con.execute("SET arrow_large_buffer_size=true")
-    
+
     try:
         # Convert s3:// URLs to GDAL format for reading
         read_url = source_url
@@ -571,19 +569,19 @@ def process_parquet_input(
             # DuckDB spatial extension can read from vsicurl
             path = source_url.replace('s3://', '')
             read_url = f"https://s3-west.nrp-nautilus.io/{path}"
-        
+
         # Check for ID column
         print("  Checking for ID column...")
         columns = con.execute(f"""
             DESCRIBE SELECT * FROM read_parquet('{read_url}') LIMIT 0
         """).fetchall()
-        
+
         column_names = [col[0].lower() for col in columns]
-        
+
         # Determine ID column
         needs_id = False
         id_col_name = None
-        
+
         if id_column:
             if id_column.lower() in column_names:
                 id_col_name = id_column
@@ -596,23 +594,23 @@ def process_parquet_input(
                 if id_name in column_names:
                     id_col_name = id_name
                     break
-            
+
             if id_col_name is None:
                 if force_id:
                     needs_id = True
                     id_col_name = "_cng_fid"
                 else:
                     raise ValueError("No ID column found and force_id=False")
-        
+
         if needs_id:
             print(f"  Adding synthetic ID column: {id_col_name}")
         else:
             print(f"  Using existing ID column: {id_col_name}")
-        
+
         # Build query to read and optionally add ID
         if needs_id:
             query = f"""
-            SELECT 
+            SELECT
                 ROW_NUMBER() OVER () AS {id_col_name},
                 *
             FROM read_parquet('{read_url}')
@@ -621,25 +619,25 @@ def process_parquet_input(
             query = f"""
             SELECT * FROM read_parquet('{read_url}')
             """
-        
+
         # Write with DuckDB
         is_s3_dest = destination.startswith('s3://')
-        
+
         if is_s3_dest:
             # Write to temp file first
             with tempfile.NamedTemporaryFile(suffix='.parquet', delete=False) as tmp:
                 tmp_path = tmp.name
-            
+
             try:
                 if verbose:
                     print(f"  Writing to temporary file: {tmp_path}")
-                
+
                 write_with_duckdb(query, tmp_path, compression, compression_level,
                                 row_group_size, verbose)
 
                 # Upload to S3
                 upload_to_s3(tmp_path, destination, verbose=progress)
-                
+
             finally:
                 if os.path.exists(tmp_path):
                     os.unlink(tmp_path)
@@ -649,7 +647,7 @@ def process_parquet_input(
                             row_group_size, verbose)
 
         print("✓ Parquet processing completed successfully!")
-        
+
     except Exception as e:
         print(f"✗ Parquet processing failed: {e}", file=sys.stderr)
         if verbose:
@@ -667,7 +665,7 @@ def write_with_duckdb(query: str, output_path: str,
                       verbose: bool = False) -> None:
     """
     Write parquet file using DuckDB COPY. Simple and reliable.
-    
+
     Args:
         query: DuckDB query that produces the data to write
         output_path: Local output file path
@@ -679,26 +677,26 @@ def write_with_duckdb(query: str, output_path: str,
     con = duckdb.connect(':memory:')
     con.install_extension("spatial")
     con.load_extension("spatial")
-    
+
     # Enable large buffer size for complex geometries (Total buffer > 2GB)
     con.execute("SET arrow_large_buffer_size=true")
-    
+
     try:
         if verbose:
             print(f"  Writing with DuckDB to {output_path}...")
-        
+
         # Use COPY - it works!
         con.execute(f"""
             COPY ({query})
             TO '{output_path}'
-            (FORMAT PARQUET, 
+            (FORMAT PARQUET,
              COMPRESSION {compression},
              ROW_GROUP_SIZE {row_group_size})
         """)
-        
+
         if verbose:
             print(f"  ✓ Wrote {output_path}")
-            
+
     finally:
         con.close()
 
@@ -707,7 +705,7 @@ def write_with_duckdb(query: str, output_path: str,
 def upload_to_s3(local_path: str, s3_destination: str, verbose: bool = True) -> None:
     """
     Upload a local file to S3 using rclone.
-    
+
     Args:
         local_path: Local file path
         s3_destination: S3 destination (s3://bucket/path)
@@ -716,24 +714,24 @@ def upload_to_s3(local_path: str, s3_destination: str, verbose: bool = True) -> 
     # Convert s3://bucket/path to rclone format nrp:bucket/path
     if not s3_destination.startswith('s3://'):
         raise ValueError(f"S3 destination must start with s3://: {s3_destination}")
-    
+
     # Parse s3://bucket/path -> nrp:bucket/path
     # The 'nrp' remote is configured in rclone for NRP Nautilus S3
     s3_path = s3_destination[5:]  # Remove s3://
     rclone_dest = f"nrp:{s3_path}"
-    
+
     if verbose:
         print(f"  Uploading {local_path} to {s3_destination}...")
-    
+
     result = subprocess.run(
         ['rclone', 'copyto', local_path, rclone_dest, '--progress'],
         capture_output=not verbose,
         text=True
     )
-    
+
     if result.returncode != 0:
         raise RuntimeError(f"rclone upload failed: {result.stderr if result.stderr else 'Unknown error'}")
-    
+
     if verbose:
         print(f"  ✓ Uploaded to {s3_destination}")
 
@@ -754,14 +752,14 @@ def convert_to_parquet(
 ):
     """
     Convert a vector dataset to optimized GeoParquet.
-    
+
     Workflow:
     1. Detect source CRS using GDAL
     2. Check if ID column exists or needs creation
     3. Build DuckDB query to read, add ID, and reproject
     4. Write GeoParquet with DuckDB COPY
     5. Upload to S3 via rclone if destination is S3
-    
+
     Args:
         source_url: Source dataset URL or list of URLs (supports s3://, http://, file paths). Multiple URLs will be merged with UNION ALL.
         destination: Output path (s3:// or local file path)
@@ -788,7 +786,7 @@ def convert_to_parquet(
         is_multi_source = False
         source_urls = [source_url]
         representative_source = source_url
-    
+
     # Check if all inputs are parquet (special handling)
     if all(is_parquet_file(url) for url in source_urls):
         # Use parquet-specific processing (no ST_Read)
@@ -807,7 +805,7 @@ def convert_to_parquet(
             target_crs=target_crs,
             verbose=verbose
         )
-    
+
     # Original processing for non-parquet inputs
     if is_multi_source:
         print(f"Converting {len(source_urls)} sources:")
@@ -818,47 +816,47 @@ def convert_to_parquet(
     if layer:
         print(f"     layer {layer}")
     print(f"       to {destination}")
-    
+
     if progress:
         print(f"  Compression: {compression} level {compression_level}")
         print(f"  Row group size: {row_group_size:,}")
-    
+
     # Check if any source is a .zip file
     has_zip = any(url.lower().endswith(".zip") for url in source_urls)
-    
+
     if has_zip and is_multi_source:
         raise ValueError("Cannot mix .zip files with multiple source URLs. Extract zip files or process separately.")
-    
+
     is_zip = source_urls[0].lower().endswith(".zip") if not is_multi_source else False
-    
+
     if is_zip:
         # Strip GDAL VSI prefixes if present so we can download the raw file
         if source_urls[0].startswith('/vsicurl/'):
             source_urls[0] = source_urls[0].replace('/vsicurl/', '')
-    
+
     try:
         temp_dir = None
         linearize_dir = None
         source_inputs = []
-        
+
         if is_zip:
             print(f"  Detected Zip archive: {source_urls[0]}")
             temp_dir = tempfile.mkdtemp()
             print(f"  Created temporary directory: {temp_dir}")
-            
+
             download_and_extract(source_urls[0], temp_dir, verbose=verbose)
-            
+
             shapefiles = find_shapefiles(temp_dir)
             if not shapefiles:
                 raise ValueError("No shapefiles found in zip archive")
-                
+
             print(f"  Found {len(shapefiles)} shapefiles in archive")
             source_inputs = shapefiles
-            
+
             # Use the first shapefile as representative for metadata
             representative_source = shapefiles[0]
             print(f"  Using {os.path.basename(representative_source)} for metadata detection")
-            
+
         elif is_multi_source:
             # Multiple non-zip sources
             print(f"  Processing {len(source_urls)} input files...")
@@ -882,7 +880,7 @@ def convert_to_parquet(
         # Step 1: Detect source CRS and geometry column
         print("  Detecting source CRS...")
         source_crs = detect_crs(representative_source, layer=layer, verbose=verbose)
-        
+
         print("  Detecting geometry column...")
         geom_col, geom_is_blob = get_geometry_column(representative_source, layer=layer, verbose=verbose)
 
@@ -939,26 +937,26 @@ def convert_to_parquet(
             verbose=verbose,
             geom_is_blob=geom_is_blob,
         )
-        
+
         # Step 3: Check ID column and wrap query if needed
         print("  Checking for ID column...")
-        needs_id, id_col_name = check_id_column(representative_source, layer=layer, id_column=id_column, 
+        needs_id, id_col_name = check_id_column(representative_source, layer=layer, id_column=id_column,
                                                   force_id=force_id, verbose=verbose)
-        
+
         if needs_id:
             print(f"  Adding synthetic ID column: {id_col_name}")
             query = add_id_column_query(query, id_col_name)
         else:
             print(f"  Using existing ID column: {id_col_name}")
-        
+
         # Step 4: Write with DuckDB
         is_s3_dest = destination.startswith('s3://')
-        
+
         if is_s3_dest:
             # Write to temp file first
             with tempfile.NamedTemporaryFile(suffix='.parquet', delete=False) as tmp:
                 tmp_path = tmp.name
-            
+
             try:
                 # Write data
                 write_with_duckdb(query, tmp_path, compression, compression_level,
@@ -966,7 +964,7 @@ def convert_to_parquet(
 
                 # Upload to S3
                 upload_to_s3(tmp_path, destination, verbose=progress)
-                
+
             finally:
                 if os.path.exists(tmp_path):
                     os.unlink(tmp_path)
@@ -977,7 +975,7 @@ def convert_to_parquet(
 
         if verbose:
             print("✓ Conversion completed successfully!")
-            
+
     except Exception as e:
         print(f"✗ Conversion failed: {e}", file=sys.stderr)
         if verbose:
@@ -1008,21 +1006,21 @@ def main():
 Examples:
   # Convert local shapefile
   cng-convert-to-parquet input.shp output.parquet
-  
+
   # Convert from S3 to S3
   cng-convert-to-parquet s3://bucket/input.shp s3://bucket/output.parquet
-  
+
   # Convert with custom compression
   cng-convert-to-parquet input.shp output.parquet --compression GZIP --compression-level 9
-  
+
   # Convert and specify ID column
   cng-convert-to-parquet input.shp output.parquet --id-column objectid
         """
     )
-    
+
     parser.add_argument("source", nargs='+', help="Source dataset URL(s) or path(s). Multiple sources will be merged with UNION ALL.")
     parser.add_argument("destination", help="Output GeoParquet path")
-    
+
     parser.add_argument("--compression", default="ZSTD",
                        choices=["ZSTD", "GZIP", "SNAPPY", "NONE"],
                        help="Compression algorithm (default: ZSTD)")
@@ -1033,24 +1031,24 @@ Examples:
     parser.add_argument("--geometry-encoding", default="WKB",
                        choices=["WKB", "WKT"],
                        help="Geometry encoding (default: WKB)")
-    
+
     parser.add_argument("--id-column", help="ID column name (auto-detected if not specified)")
     parser.add_argument("--no-force-id", action="store_true",
                        help="Don't create synthetic ID if none exists")
     parser.add_argument("--target-crs", default="EPSG:4326",
                        help="Target CRS (default: EPSG:4326)")
     parser.add_argument("--layer", help="Layer name for multi-layer datasets (e.g., GDB files)")
-    
+
     parser.add_argument("--no-progress", action="store_true",
                        help="Disable progress output")
     parser.add_argument("--verbose", action="store_true",
                        help="Enable detailed debug output")
-    
+
     args = parser.parse_args()
-    
+
     # Handle single vs multiple sources
     source_inputs = args.source if len(args.source) > 1 else args.source[0]
-    
+
     try:
         convert_to_parquet(
             source_url=source_inputs,

--- a/cng_datasets/vector/h3_tiling.py
+++ b/cng_datasets/vector/h3_tiling.py
@@ -6,9 +6,8 @@ geometries into H3 hexagonal cells at specified resolutions, with
 support for chunked processing of large datasets.
 """
 
-from typing import Optional, List, Dict, Any, Tuple
+from typing import Optional, List, Dict, Tuple
 import duckdb
-import math
 import os
 from cng_datasets.storage.s3 import configure_s3_credentials
 
@@ -40,64 +39,64 @@ def identify_id_column(
 ) -> Tuple[str, bool]:
     """
     Identify or validate an ID column in a table.
-    
+
     Uses case-insensitive matching to find common ID column names, or validates
     a user-specified column. Optionally checks for uniqueness.
-    
+
     Prioritizes _cng_fid as the standard synthetic ID column created by convert_to_parquet.
-    
+
     Args:
         con: DuckDB connection
         table_name: Name of the table or view to check
         specified_id_col: User-specified ID column name (if provided)
         check_uniqueness: Whether to validate that the ID column is unique
-        
+
     Returns:
         Tuple of (column_name, is_unique) where:
         - column_name: Actual column name in the table (preserving case)
         - is_unique: True if column is unique (or check was skipped)
-        
+
     Raises:
         ValueError: If specified column not found or uniqueness check fails
     """
     # Get all column names
     result = con.execute(f"SELECT * FROM {table_name} LIMIT 0").description
     all_columns = [col[0] for col in result]
-    
+
     # If user specified a column, validate it exists
     if specified_id_col:
         # Case-insensitive search
         col_lower_map = {col.lower(): col for col in all_columns}
         actual_col = col_lower_map.get(specified_id_col.lower())
-        
+
         if not actual_col:
             raise ValueError(f"Specified ID column '{specified_id_col}' not found in table. Available columns: {', '.join(all_columns)}")
-        
+
         id_col = actual_col
     else:
         # Auto-detect common ID column names (case-insensitive)
         # _cng_fid is our standard synthetic ID from convert_to_parquet
         col_lower_map = {col.lower(): col for col in all_columns}
         common_id_names = ['_cng_fid', 'fid', 'objectid', 'id', 'uid', 'gid', 'ogc_fid']
-        
+
         id_col = None
         for name in common_id_names:
             if name in col_lower_map:
                 id_col = col_lower_map[name]
                 break
-        
+
         if not id_col:
             # No ID column found
             return None, False
-    
+
     # Check uniqueness if requested
     is_unique = True
     if check_uniqueness:
         total_count = con.execute(f'SELECT COUNT(*) FROM {table_name}').fetchone()[0]
         unique_count = con.execute(f'SELECT COUNT(DISTINCT "{id_col}") FROM {table_name}').fetchone()[0]
-        
+
         is_unique = (total_count == unique_count)
-        
+
         if not is_unique:
             warning_msg = f"Warning: ID column '{id_col}' has {total_count} rows but only {unique_count} unique values"
             if specified_id_col:
@@ -106,7 +105,7 @@ def identify_id_column(
             else:
                 # Auto-detected, so just warn and return
                 print(f"  {warning_msg}")
-    
+
     return id_col, is_unique
 
 
@@ -119,14 +118,14 @@ def geom_to_h3_cells(
 ) -> str:
     """
     Convert geometries to H3 cells at specified resolution.
-    
+
     Args:
         con: DuckDB connection
         table_name: Name of the table or view with geometry column
         zoom: H3 resolution level (0-15)
         keep_cols: List of columns to keep from input. If None, keeps all except geom.
         geom_col: Name of the geometry column
-        
+
     Returns:
         SQL query string that generates H3 cells
     """
@@ -135,7 +134,7 @@ def geom_to_h3_cells(
         cols_query = f"SELECT * FROM {table_name} LIMIT 0"
         keep_cols = [col for col in con.execute(cols_query).description if col[0] != geom_col]
         keep_cols = [col[0] for col in keep_cols]
-    
+
     # Build column list for SELECT statements, quoting column names to handle spaces
     col_list = ', '.join([f'"{col}"' for col in keep_cols])
 
@@ -210,50 +209,50 @@ def setup_duckdb_connection(
 ) -> duckdb.DuckDBPyConnection:
     """
     Set up a DuckDB connection with required extensions.
-    
+
     Args:
         extensions: List of DuckDB extensions to load. Defaults to ["spatial"]
         http_retries: Number of HTTP retries for remote files
         http_retry_wait_ms: Wait time between retries in milliseconds
-        
+
     Returns:
         Configured DuckDB connection
     """
     if extensions is None:
         extensions = ["spatial"]
-    
+
     con = duckdb.connect()
-    
+
     # Install and load extensions
     for ext in extensions:
         con.execute(f"INSTALL {ext}")
         con.execute(f"LOAD {ext}")
-    
+
     # Install h3 from community repository
     con.execute("INSTALL h3 FROM community")
     con.execute("LOAD h3")
-    
+
     # Configure HTTP settings
     con.execute(f"SET http_retries={http_retries}")
     con.execute(f"SET http_retry_wait_ms={http_retry_wait_ms}")
-    
+
     # Configure temp directory for spill-to-disk operations
     con.execute("SET temp_directory='/tmp'")
-    
+
     # Enable large buffer size for complex geometries
     con.execute("SET arrow_large_buffer_size=true")
-    
+
     return con
 
 
 class H3VectorProcessor:
     """
     Process vector datasets into H3-indexed parquet files.
-    
+
     Handles chunked processing of large vector datasets, converting
     geometries to H3 cells and adding parent cell hierarchies.
     """
-    
+
     def __init__(
         self,
         input_url: str,
@@ -268,7 +267,7 @@ class H3VectorProcessor:
     ):
         """
         Initialize the H3 vector processor.
-        
+
         Args:
             input_url: S3 URL or local path to input parquet/geoparquet file
             output_url: S3 URL or local path to output directory
@@ -289,14 +288,14 @@ class H3VectorProcessor:
         self.id_column = id_column
         self.read_credentials = read_credentials
         self.write_credentials = write_credentials
-        
+
         self.con = setup_duckdb_connection()
         self._configure_credentials()
-        
+
     def _configure_credentials(self):
         """Configure S3 credentials for DuckDB using environment variables."""
         configure_s3_credentials(self.con)
-    
+
     def _find_geometry_column(self, table_name: str) -> str:
         """Find the geometry column in the table."""
         result = self.con.execute(f"SELECT * FROM {table_name} LIMIT 0").description
@@ -305,7 +304,7 @@ class H3VectorProcessor:
             if col.upper() in ['SHAPE', 'GEOMETRY', 'GEOM']:
                 return col
         raise ValueError(f"No geometry column found. Available columns: {columns}")
-    
+
     def process_chunk(
         self,
         chunk_id: int,
@@ -313,14 +312,14 @@ class H3VectorProcessor:
     ) -> Optional[str]:
         """
         Process a single chunk using two-pass approach to avoid OOM.
-        
+
         Pass 1: Convert geometries to H3 cell arrays (no unnesting)
         Pass 2: Read small batches, unnest arrays, write final output
-        
+
         Args:
             chunk_id: Zero-based chunk index to process
             keep_cols: List of attribute columns to keep
-            
+
         Returns:
             Output file path if successful, None if chunk_id out of range
         """
@@ -328,19 +327,19 @@ class H3VectorProcessor:
         intermediate_file = self._process_pass1(chunk_id)
         if intermediate_file is None:
             return None
-        
+
         # PASS 2: Unnest arrays in small batches
         output_file = self._process_pass2(chunk_id, intermediate_file)
-        
+
         # Clean up intermediate file
         try:
             if intermediate_file.startswith('/tmp/'):
                 os.remove(intermediate_file)
         except Exception as e:
             print(f"  Warning: Could not remove intermediate file: {e}")
-        
+
         return output_file
-    
+
     def _process_pass1(
         self,
         chunk_id: int,
@@ -350,34 +349,34 @@ class H3VectorProcessor:
         Writes intermediate parquet with arrays to disk.
         """
         offset = chunk_id * self.chunk_size
-        
+
         self.con.execute(f"""
-            CREATE OR REPLACE VIEW source_table AS 
+            CREATE OR REPLACE VIEW source_table AS
             SELECT * FROM read_parquet('{self.input_url}')
             LIMIT {self.chunk_size} OFFSET {offset}
         """)
-        
+
         chunk_rows = self.con.execute("SELECT COUNT(*) FROM source_table").fetchone()[0]
         if chunk_rows == 0:
             print(f"Chunk {chunk_id} is empty (offset {offset:,} beyond data)")
             return None
-        
+
         print(f"\nPass 1 - Chunk {chunk_id} ({chunk_rows:,} rows): Converting geometries to H3 arrays...")
-        
+
         geom_col = self._find_geometry_column('source_table')
-        
+
         id_col, is_unique = identify_id_column(
-            self.con, 
-            'source_table', 
+            self.con,
+            'source_table',
             specified_id_col=self.id_column,
             check_uniqueness=True
         )
-        
+
         if id_col is None or not is_unique:
-            print(f"  Creating synthetic ID as _fid")
+            print("  Creating synthetic ID as _fid")
             id_col = '_fid'
             self.con.execute(f"""
-                CREATE OR REPLACE VIEW source_table_with_id AS 
+                CREATE OR REPLACE VIEW source_table_with_id AS
                 SELECT row_number() OVER () - 1 + {offset} AS {id_col}, *
                 FROM source_table
             """)
@@ -385,24 +384,24 @@ class H3VectorProcessor:
         else:
             print(f"  Using ID column: {id_col}")
             chunk_view_name = 'source_table'
-        
+
         self.con.execute(f"""
-            CREATE OR REPLACE VIEW chunk_table AS 
+            CREATE OR REPLACE VIEW chunk_table AS
             SELECT "{id_col}", {geom_col} AS geom
             FROM {chunk_view_name}
         """)
-        
+
         # Generate H3 arrays WITHOUT unnesting
         h3_sql = geom_to_h3_cells(
-            self.con, 
-            'chunk_table', 
-            zoom=self.h3_resolution, 
+            self.con,
+            'chunk_table',
+            zoom=self.h3_resolution,
             keep_cols=[id_col]
         )
-        
+
         # Write arrays to intermediate file (NO UNNEST!)
         intermediate_file = f"/tmp/h3_intermediate_{chunk_id:06d}.parquet"
-        
+
         self.con.execute(f"""
             COPY ({h3_sql})
             TO '{intermediate_file}'
@@ -447,7 +446,7 @@ class H3VectorProcessor:
 
         print(f"  ✓ Pass 1 complete: {intermediate_file}")
         return intermediate_file
-    
+
     def _process_pass2(
         self,
         chunk_id: int,
@@ -457,19 +456,19 @@ class H3VectorProcessor:
         Pass 2: Read H3 arrays in small batches, unnest, and write final output.
         """
         print(f"Pass 2 - Chunk {chunk_id}: Unnesting arrays in small batches...")
-        
+
         # Get total rows in intermediate file
         total_rows = self.con.execute(
             f"SELECT COUNT(*) FROM read_parquet('{intermediate_file}')"
         ).fetchone()[0]
-        
+
         num_batches = (total_rows + self.intermediate_chunk_size - 1) // self.intermediate_chunk_size
         print(f"  Processing {total_rows} rows in {num_batches} batches of {self.intermediate_chunk_size}")
-        
+
         # Get ID column name from intermediate file
         result = self.con.execute(f"SELECT * FROM read_parquet('{intermediate_file}') LIMIT 0").description
         id_col = result[0][0]  # First column is the ID
-        
+
         # Build parent resolution columns
         h3_col = f"h{self.h3_resolution}"
         parent_cols = []
@@ -477,45 +476,45 @@ class H3VectorProcessor:
             if parent_res < self.h3_resolution:
                 col_name = f"h{parent_res}"
                 parent_cols.append(f"h3_cell_to_parent({h3_col}, {parent_res}) AS {col_name}")
-        
+
         parent_cols_str = ', ' + ', '.join(parent_cols) if parent_cols else ''
-        
+
         # Use local /tmp for fast batch processing, then copy to final destination
         local_output = f"/tmp/h3_output_{chunk_id:06d}.parquet"
         final_output = f"{self.output_url.rstrip('/')}/chunk_{chunk_id:06d}.parquet"
-        
+
         for batch_id in range(num_batches):
             batch_offset = batch_id * self.intermediate_chunk_size
-            
+
             # Read small batch and unnest
             # IMPORTANT: Use subquery to apply LIMIT/OFFSET to input rows BEFORE unnest
             # Otherwise DuckDB applies LIMIT/OFFSET to the unnested output!
             unnest_sql = f"""
-                SELECT "{id_col}", 
+                SELECT "{id_col}",
                        UNNEST(h3id) AS {h3_col}{parent_cols_str}
                 FROM (
                     SELECT * FROM read_parquet('{intermediate_file}')
                     LIMIT {self.intermediate_chunk_size} OFFSET {batch_offset}
                 )
             """
-            
+
             # Build up local file with fast local disk I/O
             if batch_id == 0:
                 # First batch: create local file
                 self.con.execute(f"""
-                    COPY ({unnest_sql}) 
-                    TO '{local_output}' 
+                    COPY ({unnest_sql})
+                    TO '{local_output}'
                     (FORMAT PARQUET, COMPRESSION 'ZSTD', ROW_GROUP_SIZE 100000)
                 """)
             else:
                 # Subsequent batches: append using local temp files
                 temp_batch_file = f"/tmp/h3_batch_{chunk_id:06d}_{batch_id}.tmp"
                 self.con.execute(f"""
-                    COPY ({unnest_sql}) 
-                    TO '{temp_batch_file}' 
+                    COPY ({unnest_sql})
+                    TO '{temp_batch_file}'
                     (FORMAT PARQUET, COMPRESSION 'ZSTD')
                 """)
-                
+
                 # Merge into local output using fast local disk
                 self.con.execute(f"""
                     COPY (
@@ -523,17 +522,17 @@ class H3VectorProcessor:
                         UNION ALL
                         SELECT * FROM read_parquet('{temp_batch_file}')
                     )
-                    TO '{local_output}.new' 
+                    TO '{local_output}.new'
                     (FORMAT PARQUET, COMPRESSION 'ZSTD', ROW_GROUP_SIZE 100000)
                 """)
-                
+
                 # Fast local file operations
                 os.replace(f"{local_output}.new", local_output)
                 os.remove(temp_batch_file)
-            
+
             if (batch_id + 1) % 10 == 0 or batch_id == num_batches - 1:
                 print(f"  Progress: {batch_id + 1}/{num_batches} batches")
-        
+
         # Final step: copy completed file to S3 (single write operation)
         print(f"  Writing final output to {final_output}...")
         self.con.execute(f"""
@@ -541,20 +540,20 @@ class H3VectorProcessor:
             TO '{final_output}'
             (FORMAT PARQUET, COMPRESSION 'ZSTD', ROW_GROUP_SIZE 100000)
         """)
-        
+
         # Clean up local file
         try:
             os.remove(local_output)
         except Exception as e:
             print(f"  Warning: Could not remove local output file: {e}")
-        
+
         print(f"  ✓ Pass 2 complete: {final_output}")
         return final_output
-    
+
     def process_all_chunks(self) -> List[str]:
         """
         Process all chunks in the dataset.
-        
+
         Returns:
             List of output file paths
         """
@@ -562,17 +561,17 @@ class H3VectorProcessor:
         total_rows = self.con.execute(
             f"SELECT COUNT(*) FROM read_parquet('{self.input_url}')"
         ).fetchone()[0]
-        
+
         num_chunks = (total_rows + self.chunk_size - 1) // self.chunk_size
-        
+
         print(f"Processing {total_rows} rows in {num_chunks} chunks...")
-        
+
         output_files = []
         for chunk_id in range(num_chunks):
             output_file = self.process_chunk(chunk_id)
             if output_file:
                 output_files.append(output_file)
-        
+
         return output_files
 
 
@@ -588,7 +587,7 @@ def process_vector_chunks(
 ) -> Optional[List[str]]:
     """
     Convenience function to process vector data into H3-indexed chunks.
-    
+
     Args:
         input_url: S3 URL or local path to input file
         output_url: S3 URL or local path to output directory
@@ -598,7 +597,7 @@ def process_vector_chunks(
         chunk_size: Number of rows per chunk in pass 1
         intermediate_chunk_size: Number of rows per batch in pass 2 (unnesting)
         **kwargs: Additional arguments passed to H3VectorProcessor
-        
+
     Returns:
         List of output file paths, or None if single chunk was out of range
     """
@@ -611,7 +610,7 @@ def process_vector_chunks(
         intermediate_chunk_size=intermediate_chunk_size,
         **kwargs
     )
-    
+
     if chunk_id is not None:
         output_file = processor.process_chunk(chunk_id)
         return [output_file] if output_file else None

--- a/cng_datasets/vector/repartition.py
+++ b/cng_datasets/vector/repartition.py
@@ -11,7 +11,6 @@ import subprocess
 import duckdb
 import ibis
 from cng_datasets.storage.s3 import configure_s3_credentials
-from cng_datasets.vector.h3_tiling import identify_id_column
 
 
 def repartition_by_h0(
@@ -47,11 +46,11 @@ def repartition_by_h0(
     con.raw_sql('SET http_timeout=1200')
     con.raw_sql('SET http_retries=30')
     con.raw_sql('SET arrow_large_buffer_size=true')
-    
+
     # Create local temporary directory
     local_dir = '/tmp/hex'
     os.makedirs(local_dir, exist_ok=True)
-    
+
     # Read chunks (sparse format: ID_column, h10, h9, h8, h0)
     try:
         chunks = con.read_parquet(f'{chunks_dir}/*.parquet')
@@ -62,30 +61,30 @@ def repartition_by_h0(
             f"Original error: {e}"
         ) from e
     chunk_cols = chunks.columns
-    
+
     # Identify ID column in chunks
     # Prioritize _cng_fid (standard from convert_to_parquet), then _fid (fallback), then other non-h3 columns
     chunk_id_col = None
     priority_ids = ['_cng_fid', '_fid']
-    
+
     # First check for priority IDs
     for priority_id in priority_ids:
         if priority_id in chunk_cols:
             chunk_id_col = priority_id
             break
-    
+
     # If no priority ID found, look for any non-h3 column
     if not chunk_id_col:
         for col in chunk_cols:
             if not col.startswith('h') or not col[1:].isdigit():
                 chunk_id_col = col
                 break
-    
+
     if not chunk_id_col:
         raise ValueError(f"Could not identify ID column in chunks. Columns: {chunk_cols}")
-    
+
     print(f"Chunks ID column: {chunk_id_col}")
-    
+
     # If source parquet provided, join back all attributes (except geometry)
     if source_parquet:
         print(f'Joining attributes from {source_parquet}...')
@@ -194,9 +193,9 @@ def repartition_by_h0(
 
     print('Cleaning up local directory...')
     shutil.rmtree(local_dir, ignore_errors=True)
-    
+
     print('✓ Repartitioning complete!')
-    
+
     # Clean up chunks directory if requested
     if cleanup and chunks_dir.startswith('s3://'):
         print('Removing chunks directory from S3...')
@@ -207,7 +206,7 @@ def repartition_by_h0(
             rclone_path = f'nrp:{bucket}/{path}'
         else:
             rclone_path = f'nrp:{parts[0]}'
-        
+
         try:
             result = subprocess.run(
                 ['rclone', 'purge', rclone_path],
@@ -221,5 +220,5 @@ def repartition_by_h0(
                 print(f'⚠ rclone cleanup warning: {result.stderr}')
         except Exception as e:
             print(f'⚠ Error during cleanup: {e}')
-    
+
     print('✓ All done!')


### PR DESCRIPTION
Closes #90.

The CI ruff step (`ruff check cng_datasets/ --select E,F,W --ignore E501`) was `continue-on-error: true`, so a backlog of **521** E/F/W violations had accumulated unnoticed. This clears them and flips the step to blocking so new violations are caught going forward.

## Changes

| count | code | resolution |
|---|---|---|
| 467 | W293 / W291 | Removed trailing / blank-line whitespace. Includes occurrences inside docstrings (applied via `--unsafe-fixes`, scoped to `W291,W293`). |
| 40 | F541 | Dropped the `f` prefix from f-strings with no placeholders (behavior-identical). |
| 12 | F401 | Removed unused imports (e.g. `pathlib.Path`, `dataclasses.field`). |
| 2 | E722 | Narrowed bare `except:` in `setup_bucket.py` to the JSON-parse exceptions actually raised (`ValueError`/`KeyError`/`TypeError`). |

Then removed `continue-on-error: true` from the lint step in `.github/workflows/test.yml`.

## Verification

- `ruff check cng_datasets/ --select E,F,W --ignore E501` → **All checks passed!** (exit 0) in `datasets:latest`.
- `git diff -w` confirms the **only** non-whitespace changes are the F401/F541/E722 items above — the rest is pure whitespace, behavior-neutral.
- k8s generator tests: 54 passed offline; the 2 failures are network-bound (remote `ogrinfo` feature-count fallback), not regressions — they pass in CI which has network.

Per the issue, kept separate from data/pipeline PRs to avoid noisy diffs. Stacks cleanly on the now-merged #86.