### PR TITLE
feat(#95): add max/min to --hex-resampling for peak/richness rasters

### DIFF
--- a/cng_datasets/cli.py
+++ b/cng_datasets/cli.py
@@ -46,7 +46,8 @@ def main():
     raster_parser.add_argument("--hex-resampling", default="mean",
                                help="Reducer for aggregating source pixels into each "
                                     "H3 cell. With --method=exact-extract (default), "
-                                    "one of: sum/mean/mode. With --method=warp-centroid, "
+                                    "one of: sum/mean/mode/max/min (max/min for "
+                                    "peak/richness rasters). With --method=warp-centroid, "
                                     "any GDAL resampleAlg (average, sum, mode, near, "
                                     "bilinear, cubic, ...). Default: mean.")
     raster_parser.add_argument("--method", default="exact-extract",
@@ -131,9 +132,10 @@ def main():
     raster_workflow_parser.add_argument("--nodata", type=float, help="NoData value to exclude")
     raster_workflow_parser.add_argument("--hex-resampling", default="mean",
                                         choices=VALID_HEX_REDUCERS,
-                                        help="Area-weighted reducer for H3 aggregation. 'sum' for "
+                                        help="Reducer for H3 aggregation. 'sum' for "
                                              "counts (population, carbon); 'mean' for intensities; "
-                                             "'mode' for categorical. Default: mean.")
+                                             "'mode' for categorical; 'max'/'min' for peak/extremum "
+                                             "(species richness). Default: mean.")
     raster_workflow_parser.add_argument("--hex-memory", type=str, default="32Gi", help="Memory per hex job pod (default: 32Gi)")
     raster_workflow_parser.add_argument("--max-parallelism", type=int, default=61, help="Maximum parallel hex jobs (default: 61)")
     raster_workflow_parser.add_argument("--hex-storage", type=str, default="20Gi", help="Ephemeral storage request/limit per hex job pod (default: 20Gi)")

--- a/cng_datasets/raster/cog.py
+++ b/cng_datasets/raster/cog.py
@@ -236,10 +236,13 @@ def _configure_proj():
 _configure_proj()
 
 
-# Area-weighted reducers supported by the H3 hex aggregator (#84).
+# Reducers supported by the exact-extract H3 hex aggregator. "sum"/"mean" are
+# coverage-weighted (#84); "mode" is the categorical majority; "max"/"min" are
+# coverage-agnostic extrema for peak/"max-over-area" rasters like species
+# richness, where sum double-counts and mean averages away the hotspot (#95).
 # Used both for runtime validation in RasterProcessor.__init__ and as
 # argparse `choices=` in the CLI.
-VALID_HEX_REDUCERS = ("sum", "mean", "mode")
+VALID_HEX_REDUCERS = ("sum", "mean", "mode", "max", "min")
 
 # Two implementations of the raster → H3 hex aggregation step.
 # - "exact-extract" (default): polyfill h0 → cells, exact_extract per-cell.
@@ -729,7 +732,9 @@ class RasterProcessor:
             hex_resampling: Reducer for aggregating source pixels into each
                 H3 cell. With method="exact-extract" (default), one of:
                 "sum" (counts/stocks like population), "mean" (intensities
-                like NDVI), "mode" (categorical like land cover). With
+                like NDVI), "mode" (categorical like land cover), "max"/"min"
+                (peak/extremum like species richness, where sum double-counts
+                and mean averages away the hotspot). With
                 method="warp-centroid", any GDAL resampleAlg is accepted
                 ("average", "sum", "mode", "near", "bilinear", "cubic", ...).
                 Default: "mean".
@@ -825,7 +830,7 @@ class RasterProcessor:
         self.method = method
 
         # hex_resampling vocabulary depends on the method.
-        # exact-extract: only the area-weighted reducers (sum/mean/mode).
+        # exact-extract: only the exact-extract reducers (sum/mean/mode/max/min).
         # warp-centroid: any GDAL resampleAlg is forwarded to gdal.Warp.
         if method == "exact-extract":
             if hex_resampling not in VALID_HEX_REDUCERS:

--- a/tests/test_raster.py
+++ b/tests/test_raster.py
@@ -284,7 +284,21 @@ class TestRasterProcessor:
             hex_resampling="mode",
         )
         assert processor.hex_resampling == "mode"
-    
+
+    @pytest.mark.timeout(60)
+    @pytest.mark.parametrize("reducer", ["max", "min"])
+    def test_raster_processor_hex_resampling_max_min(self, small_raster, reducer):
+        """Peak/extremum rasters (e.g. species richness) need max/min reducers
+        (issue #95). sum double-counts and mean averages away the hotspot."""
+        from cng_datasets.raster import RasterProcessor
+
+        processor = RasterProcessor(
+            input_path=small_raster,
+            h3_resolution=6,
+            hex_resampling=reducer,
+        )
+        assert processor.hex_resampling == reducer
+
     @pytest.mark.timeout(60)
     def test_raster_processor_auto_detect(self, small_raster):
         """Test RasterProcessor with auto-detected resolution."""
@@ -1131,6 +1145,98 @@ class TestWarpCentroidMethod:
         df = proc.con.read_parquet(result).fetchdf()
         assert {"v", "h7", "h0"}.issubset(df.columns)
         assert len(df) > 0
+
+
+class TestHexResamplingMaxMin:
+    """Issue #95: peak/extremum rasters (species richness, IUCN richness) must
+    aggregate to a hex cell's MAX over its footprint, not sum (double-counts
+    species) or mean (averages away the hotspot). max/min are coverage-agnostic
+    — the cell extremum is independent of fractional pixel coverage — so they
+    forward straight to exactextract's first-class `max`/`min` ops."""
+
+    @pytest.fixture
+    def temp_dir(self):
+        d = tempfile.mkdtemp()
+        yield d
+        shutil.rmtree(d, ignore_errors=True)
+
+    @pytest.fixture
+    def striped_raster(self, temp_dir):
+        """A global 1-degree raster striped by latitude row: value 9.0 on even
+        rows, 1.0 on odd rows. A per-cell extremum (max/min) must return one of
+        the two actual pixel values; a MEAN would return intermediate values
+        (~5) and a SUM would return values far above 9 — so every output value
+        landing in {1.0, 9.0} discriminates an extremum reducer from both, and
+        the peak 9.0 being present proves max preserved the hotspot."""
+        from osgeo import gdal, osr
+        path = os.path.join(temp_dir, "striped.tif")
+        ds = gdal.GetDriverByName("GTiff").Create(path, 360, 180, 1, gdal.GDT_Float32)
+        ds.SetGeoTransform([-180.0, 1.0, 0, 90.0, 0, -1.0])
+        srs = osr.SpatialReference(); srs.ImportFromEPSG(4326)
+        ds.SetProjection(srs.ExportToWkt())
+        arr = np.ones((180, 360), dtype=np.float32)
+        arr[::2, :] = 9.0  # even rows = 9, odd rows = 1
+        ds.GetRasterBand(1).WriteArray(arr)
+        ds.FlushCache(); ds = None
+        return path
+
+    def _run(self, striped_raster, temp_dir, reducer):
+        from cng_datasets.raster import RasterProcessor
+        import geopandas as gpd
+        from shapely.geometry import box
+
+        grid = os.path.join(temp_dir, f"grid_{reducer}.parquet")
+        gpd.GeoDataFrame(
+            {"i": [0], "h0": [578536630256664575], "geometry": [box(-180, -90, 180, 90)]},
+            crs="EPSG:4326",
+        ).rename_geometry("geom").to_parquet(grid)
+
+        out_dir = os.path.join(temp_dir, f"hex_{reducer}")
+        proc = RasterProcessor(
+            input_path=striped_raster,
+            output_parquet_path=out_dir,
+            h3_resolution=3,
+            parent_resolutions=[0],
+            h0_grid_path=grid,
+            value_column="richness",
+            hex_resampling=reducer,
+        )
+        result = proc.process_h0_region(0)
+        assert result, f"expected output for a global raster ({reducer})"
+        con = duckdb.connect()
+        return con.execute(
+            f"SELECT richness FROM read_parquet('{result}')"
+        ).fetchdf()["richness"].tolist()
+
+    @requires_gdal
+    @pytest.mark.timeout(180)
+    def test_max_reducer_returns_per_cell_maximum(self, striped_raster, temp_dir):
+        vals = self._run(striped_raster, temp_dir, "max")
+        assert len(vals) > 0
+        # Every output value must be one of the actual pixel values {1.0, 9.0}:
+        # a mean would yield intermediates (~5) and a sum values far above 9.
+        assert all(abs(v - 1.0) < 1e-4 or abs(v - 9.0) < 1e-4 for v in vals), (
+            f"max output not an extremum of pixel values: "
+            f"min={min(vals):.3f} max={max(vals):.3f} (expected values in {{1,9}})"
+        )
+        # The peak (9.0) must survive — max must not average the hotspot away.
+        assert max(vals) == pytest.approx(9.0, abs=1e-4), (
+            f"max reducer lost the peak: max={max(vals):.3f} (expected 9.0)"
+        )
+
+    @requires_gdal
+    @pytest.mark.timeout(180)
+    def test_min_reducer_returns_per_cell_minimum(self, striped_raster, temp_dir):
+        vals = self._run(striped_raster, temp_dir, "min")
+        assert len(vals) > 0
+        assert all(abs(v - 1.0) < 1e-4 or abs(v - 9.0) < 1e-4 for v in vals), (
+            f"min output not an extremum of pixel values: "
+            f"min={min(vals):.3f} max={max(vals):.3f} (expected values in {{1,9}})"
+        )
+        # The trough (1.0) must survive — min must not average it away.
+        assert min(vals) == pytest.approx(1.0, abs=1e-4), (
+            f"min reducer lost the trough: min={min(vals):.3f} (expected 1.0)"
+        )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Closes #95.

## Problem

`VALID_HEX_REDUCERS = ("sum", "mean", "mode")` exposed only three reducers, none of which correctly hexes a **peak / max-over-area** raster such as species richness (MOBI, IUCN):

- `sum` double-counts species across the pixels in a cell (richness 12 + 12 ≠ 24 species).
- `mean` understates hotspots by averaging the peak away.

The intended quantity is the per-cell **maximum** (or minimum).

## Fix

`exactextract` already supports `max`/`min` as first-class ops, and the pipeline forwards the reducer name straight through (`exact_extract(rast, vec, ops=[op_name])`). `max`/`min` are coverage-agnostic — a cell's extremum is independent of fractional pixel coverage — so no new aggregation code is needed:

- **`cog.py`**: add `"max"`/`"min"` to `VALID_HEX_REDUCERS` (drives both the runtime validation in `RasterProcessor.__init__` and the `raster-workflow` argparse `choices=`); update the comments and the `hex_resampling` docstring.
- **`cli.py`**: list `max`/`min` in both `--hex-resampling` help texts.

## Tests

- `test_raster_processor_hex_resampling_max_min[max,min]` — constructor accepts both reducers.
- `TestHexResamplingMaxMin` — end-to-end correctness on a latitude-striped raster (even rows 9.0, odd rows 1.0): every output value is an actual pixel value (`{1.0, 9.0}`, never a summed ≫9 or averaged ~5), `max` preserves the peak (9.0) and `min` the trough (1.0). This is the per-cell-maximum assertion the issue asked for.

## Verification

- New tests pass (verified failing first against the old whitelist).
- Full raster suite: **35 passed** (run in `ghcr.io/boettiger-lab/datasets:latest`).
- CI lint reproduced locally: `ruff check cng_datasets/ --select E,F,W --ignore E501` → clean.