### PR TITLE
docs: make agent instructions Docker-based, drop local venv

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -13,9 +13,14 @@ Do NOT read or modify `cng_datasets/` source code unless you are fixing a bug in
 
 ## Local Environment
 
-Activate the virtualenv: `source .venv/bin/activate`
+This project is Docker-based — there is no local virtualenv. Run the `cng-datasets` CLI from the project's version-stable image, which pins every dependency (GDAL, PROJ, exactextract, h3, ...). The image is the source of truth for what's installed; don't assume versions:
 
-The `cng-datasets` CLI is installed in the venv. Use it to generate k8s job YAML files. Do not run processing commands (vector, raster, repartition) locally — those run inside k8s pods.
+```bash
+docker run --rm -v "$PWD":/app -w /app ghcr.io/boettiger-lab/datasets:latest \
+  cng-datasets workflow --dataset <name> ...
+```
+
+Use the CLI only to generate k8s job YAML files. Do not run processing commands (vector, raster, repartition) locally — those run inside k8s pods.
 
 ## Kubernetes
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -14,6 +14,8 @@ You are taking source geospatial data and producing three outputs per dataset:
 
 You do **not** process data locally. You generate Kubernetes jobs that do the processing on the cluster.
 
+The `cng-datasets` CLI and all its dependencies (GDAL, PROJ, exactextract, ...) are provided by the project's Docker image — there is no local virtualenv. Run the CLI from the image, e.g. `docker run --rm -v "$PWD":/app -w /app ghcr.io/boettiger-lab/datasets:latest cng-datasets ...`. The `cng-datasets ...` commands below are what you run inside that container.
+
 ## How To Process a Dataset
 
 ### Step 1: Identify the source data


### PR DESCRIPTION
The agent-facing docs told agents to `source .venv/bin/activate` and treat a local virtualenv as where the `cng-datasets` CLI lives. These projects run on fully dockerized, version-stable images in every environment — the image is the source of truth for installed packages and versions, not a local venv (which has now been removed locally).

## Changes
- **`.github/copilot-instructions.md`** — replaced the venv-activation "Local Environment" section with running the CLI from the project Docker image (`ghcr.io/boettiger-lab/datasets:latest`).
- **`AGENTS.md`** — added a note that the CLI and its deps (GDAL, PROJ, exactextract, ...) come from the image, and the `cng-datasets ...` commands are what you run inside that container.

## Scope
Agent-facing instructions only, per request. The human contributor/install docs (`README.md`, `CONTRIBUTING.md`, `docs/`) still document a pip/venv flow and are intentionally left for a separate pass.