### PR TITLE
fix(#99): mount rclone-config in generated raster hex job

### DIFF
--- a/cng_datasets/k8s/workflows.py
+++ b/cng_datasets/k8s/workflows.py
@@ -925,12 +925,18 @@ fi
                 {"name": "PYTHONPATH", "value": "/usr/lib/python3/dist-packages"},
                 {"name": "BUCKET", "value": bucket}
             ],
+            "volumeMounts": [
+                {"name": "rclone-config", "mountPath": "/root/.config/rclone", "readOnly": True}
+            ],
             "command": ["bash", "-c", command_str],
             "resources": {
                 "requests": {"cpu": "4", "memory": hex_memory, "ephemeral-storage": hex_storage},
                 "limits": {"cpu": "4", "memory": hex_memory, "ephemeral-storage": hex_storage}
             }
-        }]
+        }],
+        "volumes": [
+            {"name": "rclone-config", "secret": {"secretName": config.rclone_secret_name}}
+        ]
     }
     _apply_scheduling(pod_spec, config)
     job_spec = {

--- a/tests/test_k8s_workflows.py
+++ b/tests/test_k8s_workflows.py
@@ -914,6 +914,27 @@ class TestClusterConfig:
             pod_spec = hex_job["spec"]["template"]["spec"]
             assert "affinity" not in pod_spec
 
+    @pytest.mark.timeout(5)
+    def test_raster_hex_job_mounts_rclone_config(self):
+        """Hex job must mount rclone-config so _localize_input can rclone-copy the COG (issue #99)."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            generate_raster_workflow(
+                dataset_name="raster-cfg",
+                source_urls="https://example.com/tile.tif",
+                bucket="test-bucket",
+                output_dir=tmpdir,
+                rclone_secret_name="my-rclone-secret",
+            )
+            hex_job = yaml.safe_load(open(Path(tmpdir) / "raster-cfg-hex.yaml"))
+            pod_spec = hex_job["spec"]["template"]["spec"]
+            rclone_vol = next(v for v in pod_spec["volumes"] if v["name"] == "rclone-config")
+            assert rclone_vol["secret"]["secretName"] == "my-rclone-secret"
+            mount = next(
+                m for m in pod_spec["containers"][0]["volumeMounts"]
+                if m["name"] == "rclone-config"
+            )
+            assert mount["mountPath"] == "/root/.config/rclone"
+
 
 class TestProfileLoading:
     """Tests for load_profile() and cluster_config_from_args()."""


### PR DESCRIPTION
## Problem

Fixes #99. The hex job emitted by `cng-datasets raster-workflow` built its `pod_spec` with only env/command/resources and **no `volumeMounts`/`volumes`**, unlike every sibling job generator (setup-bucket, preprocess-cog, pmtiles, convert, repartition).

With no rclone config mounted, `RasterProcessor._localize_input` (`raster/cog.py`) could not `rclone copy` the COG to local NVMe, and the `/vsis3` GDAL fallback also failed on internal S3 endpoints (`AWS_S3_ENDPOINT=rook-ceph-rgw-nautiluss3.rook`, `AWS_HTTPS=false`) — so the job died before hexing:

```
Failed to create file system for "nrp:...": didn't find section in config file
⚠ rclone copy failed (...); falling back to GDAL VSI copy
RuntimeError: Could not open remote source for localization: /vsis3/...cog.tif
```

## Fix

`_generate_raster_hex_job` now adds the `rclone-config` volume + mount (honoring `config.rclone_secret_name`) to the hex pod, identical to the other generated jobs.

## Tests

Added `test_raster_hex_job_mounts_rclone_config` asserting the hex pod mounts the secret at `/root/.config/rclone` and respects a custom `--rclone-secret-name`.

Verified the generated `*-hex.yaml` now contains:
```
volumes: [{'name': 'rclone-config', 'secret': {'secretName': 'my-rclone-secret'}}]
mounts : [{'name': 'rclone-config', 'mountPath': '/root/.config/rclone', 'readOnly': True}]
```

Context: surfaced while re-hexing raster datasets in boettiger-lab/data-workflows#186.