### PR TITLE
fix: deterministic, lazy PROJ db configuration

### DIFF
--- a/cng_datasets/k8s/workflows.py
+++ b/cng_datasets/k8s/workflows.py
@@ -821,14 +821,11 @@ def _generate_cog_preprocess_job(
     if nodata_value is not None:
         optional_flags += f"\n  --nodata {nodata_value} \\"
 
+    # PROJ database selection is handled deterministically inside the CLI
+    # (cog._configure_proj picks the highest-version proj.db, MINOR>=7). A bash
+    # `find ... | head -1` here would be non-deterministic and could export a
+    # stale PROJ_DATA — see issue #91.
     command_str = f"""set -e
-
-# Locate PROJ database
-PROJ_DB=$(find /usr /opt -name "proj.db" 2>/dev/null | head -1)
-if [ -n "$PROJ_DB" ]; then
-  export PROJ_DATA="$(dirname $PROJ_DB)"
-  export PROJ_LIB="$PROJ_DATA"
-fi
 
 echo "Mosaicking {len(source_urls)} tiles → {output_cog_url}"
 
@@ -903,14 +900,11 @@ def _generate_raster_hex_job(
     if nodata_value is not None:
         cng_cmd += f" --nodata {nodata_value}"
 
+    # PROJ database selection is handled deterministically inside the CLI
+    # (cog._configure_proj picks the highest-version proj.db, MINOR>=7). A bash
+    # `find ... | head -1` here would be non-deterministic and could export a
+    # stale PROJ_DATA — see issue #91.
     command_str = f"""set -e
-
-# Locate PROJ database dynamically to avoid version mismatches
-PROJ_DB=$(find /usr /opt -name "proj.db" 2>/dev/null | head -1)
-if [ -n "$PROJ_DB" ]; then
-  export PROJ_DATA="$(dirname $PROJ_DB)"
-  export PROJ_LIB="$PROJ_DATA"
-fi
 
 {cng_cmd}"""
 

--- a/cng_datasets/raster/cog.py
+++ b/cng_datasets/raster/cog.py
@@ -207,6 +207,9 @@ def _select_proj_db(candidates, min_minor: int = _PROJ_MIN_MINOR):
     return best if best_minor >= min_minor else None
 
 
+_proj_configured = False
+
+
 def _configure_proj():
     """Find the best PROJ database on the system and point GDAL at it.
 
@@ -215,7 +218,24 @@ def _configure_proj():
     take precedence. Choose the highest-version db deterministically; if none
     meets the minimum, leave GDAL's existing configuration alone rather than
     forcing a stale db.
+
+    Lazy and idempotent: the first reprojecting entrypoint (RasterProcessor,
+    create_mosaic_cog) calls this; it runs at most once per process. It used to
+    run at import time, so even YAML-generation and unit-test imports paid for
+    the full-filesystem `find` — slow on container overlay filesystems and the
+    cause of spurious test timeouts (issue #99 fallout).
+
+    This deliberately re-runs the deterministic `_select_proj_db` scan even when
+    PROJ_DATA is already exported: the generated k8s job's bash wrapper sets
+    PROJ_DATA from `find ... | head -1`, which is non-deterministic and can land
+    on the stale Ubuntu db (MINOR == 6). Python's selection is authoritative and
+    overrides it — trusting the pre-set value would reintroduce that race.
     """
+    global _proj_configured
+    if _proj_configured:
+        return
+    _proj_configured = True
+
     import subprocess
 
     try:
@@ -232,8 +252,6 @@ def _configure_proj():
             gdal.SetConfigOption("PROJ_DATA", proj_dir)
     except Exception:
         pass
-
-_configure_proj()
 
 
 # Reducers supported by the exact-extract H3 hex aggregator. "sum"/"mean" are
@@ -556,6 +574,7 @@ def create_mosaic_cog(
     if not source_urls:
         raise ValueError("source_urls must not be empty")
 
+    _configure_proj()
     print(f"Creating mosaic COG from {len(source_urls)} source tile(s)...")
 
     # Resolve VSI paths for all sources
@@ -754,6 +773,7 @@ class RasterProcessor:
             read_credentials: Dict with AWS credentials for reading
             write_credentials: Dict with AWS credentials for writing
         """
+        _configure_proj()
         # If a list of tiles is provided, mosaic them into a temp COG first
         self._mosaic_tmpdir = None
         if isinstance(input_path, list):

--- a/tests/test_raster.py
+++ b/tests/test_raster.py
@@ -1043,6 +1043,40 @@ class TestProjDbSelection:
         good = self._make_proj_db(str(tmp_path / "gdal" / "proj.db"), 9)
         assert _select_proj_db([str(bad), good]) == good
 
+    def test_overrides_stale_preset_proj_data(self, tmp_path, monkeypatch):
+        """_configure_proj must run its deterministic scan even when PROJ_DATA is
+        already exported. The generated k8s job's bash wrapper sets PROJ_DATA from
+        `find ... | head -1` (non-deterministic, can land on the stale MINOR==6 db
+        — issue #91). Trusting that pre-set value would reintroduce the flaky
+        version-mismatch race, so Python's selection must override it."""
+        import subprocess
+        from cng_datasets.raster import cog
+        good_dir = tmp_path / "gdal"
+        self._make_proj_db(str(good_dir / "proj.db"), 9)
+
+        monkeypatch.setenv("PROJ_DATA", "/some/stale/dir")
+        monkeypatch.setattr(cog, "_proj_configured", False)
+
+        class _Result:
+            stdout = str(good_dir / "proj.db") + "\n"
+        monkeypatch.setattr(subprocess, "run", lambda *a, **k: _Result())
+
+        cog._configure_proj()
+        assert os.environ["PROJ_DATA"] == str(good_dir), "stale pre-set value must be overridden"
+
+    def test_configure_proj_runs_once(self, monkeypatch):
+        """The scan is guarded so it runs at most once per process — repeated
+        entrypoint calls (RasterProcessor, create_mosaic_cog) don't re-`find`."""
+        import subprocess
+        from cng_datasets.raster import cog
+        monkeypatch.setattr(cog, "_proj_configured", False)
+        calls = []
+        monkeypatch.setattr(subprocess, "run",
+                            lambda *a, **k: calls.append(1) or type("R", (), {"stdout": ""})())
+        cog._configure_proj()
+        cog._configure_proj()
+        assert len(calls) == 1
+
 
 class TestWarpCentroidMethod:
     """PR #86: the opt-in warp-centroid fallback method (gdal.Warp -> XYZ ->


### PR DESCRIPTION
## Problem

Two issues, same root: PROJ database selection.

1. **Import-time scan.** `_configure_proj()` ran a full-filesystem `find /usr /opt /root -name proj.db` **at module import** (`raster/cog.py`). Merely *importing* `cng_datasets.raster.cog` — to generate workflow YAML (`generate_raster_workflow` → `is_cog`), run a unit test, or call any helper — paid for that scan. On container overlay filesystems with a cold cache it exceeds the unit tests' `@pytest.mark.timeout(5)` during collection, so small, well-scoped changes (e.g. #100) became spuriously hard to verify.

2. **Non-deterministic bash wrapper.** The generated mosaic-cog and hex k8s jobs exported `PROJ_DATA` from `find ... | head -1` — non-deterministic, and able to land on the stale Ubuntu db (`MINOR==6`), the exact #91 race.

## Fix

- **Lazy + once-guarded scan.** Defer `_configure_proj()` to the two entrypoints that actually reproject — `RasterProcessor.__init__` and `create_mosaic_cog` — and run it at most once per process. Import is now instant (~1.3s, just GDAL/duckdb); the scan happens only on a real raster run, where its cost is negligible against the raster I/O. `is_cog`, `detect_nodata_value`, and `detect_optimal_h3_resolution` read only metadata/geotransform (no reprojection), so they stay scan-free.
- **Deterministic selection stays authoritative.** `_configure_proj` re-runs the highest-version (`MINOR>=7`) `_select_proj_db` scan every process and **overrides** any pre-set `PROJ_DATA`. It deliberately does *not* trust a pre-set value — doing so would reintroduce the #91 race.
- **Removed the bash `PROJ_DB` blocks** from both generated job wrappers. They only invoke `cng-datasets raster`, which now self-configures deterministically, so the `find | head -1` block was both redundant and the source of the non-determinism.

## Tests

- `TestProjDbSelection::test_overrides_stale_preset_proj_data` — a stale pre-set `PROJ_DATA` is overridden by the deterministic scan.
- `TestProjDbSelection::test_configure_proj_runs_once` — the run-once guard holds.
- Verified on the Docker image: `PROJ_DATA=/some/stale/dir` → `RasterProcessor.__init__` overrides it to `/usr/local/gdal-internal/share/proj` (MINOR 7); generated YAML contains no `PROJ_DB`/`proj.db` find blocks.
- Full `tests/test_raster.py` (37 passed) and raster `tests/test_k8s_workflows.py` (21 passed) green; k8s tests run **without** cache-warming workarounds.
