### PR TITLE
fix(#35,#79,#87): expose range-read headers in bucket CORS

### DIFF
--- a/cng_datasets/storage/s3.py
+++ b/cng_datasets/storage/s3.py
@@ -10,6 +10,22 @@ import json
 import os
 
 
+# Response headers a browser must be allowed to read cross-origin for
+# HTTP Range-based rendering — PMTiles tile fetches and COG byte-range reads.
+# Accept-Ranges and Content-Range are NOT CORS-safelisted, so without explicit
+# exposure a JS client cannot see them and range reads fail silently even
+# though `curl` works (issues #35, #79, #87). Defined once and shared by both
+# CORS code paths (S3Manager.configure_cors and setup_public_bucket) so the two
+# can never drift apart again.
+CORS_EXPOSE_HEADERS = [
+    "ETag",
+    "Content-Length",
+    "Content-Type",
+    "Accept-Ranges",
+    "Content-Range",
+]
+
+
 def configure_s3_credentials(con) -> None:
     """
     Configure S3 credentials for DuckDB using environment variables.
@@ -147,6 +163,7 @@ class S3Manager:
                 'AllowedOrigins': allowed_origins,
                 'AllowedMethods': allowed_methods,
                 'AllowedHeaders': ['*'],
+                'ExposeHeaders': CORS_EXPOSE_HEADERS,
                 'MaxAgeSeconds': 3600
             }]
         }

--- a/cng_datasets/storage/setup_bucket.py
+++ b/cng_datasets/storage/setup_bucket.py
@@ -11,6 +11,8 @@ import json
 import os
 from typing import Optional
 
+from .s3 import CORS_EXPOSE_HEADERS
+
 
 def setup_public_bucket(
     bucket_name: str,
@@ -137,7 +139,9 @@ def setup_public_bucket(
                     "AllowedOrigins": ["*"],
                     "AllowedMethods": ["GET", "HEAD"],
                     "AllowedHeaders": ["*"],
-                    "ExposeHeaders": ["ETag", "Content-Type", "Content-Disposition"],
+                    # Range-read headers for PMTiles/COG browser rendering
+                    # (issues #35, #79, #87); shared with S3Manager.configure_cors.
+                    "ExposeHeaders": CORS_EXPOSE_HEADERS,
                     "MaxAgeSeconds": 3600
                 }]
             }

--- a/tests/test_storage.py
+++ b/tests/test_storage.py
@@ -1,0 +1,88 @@
+"""Tests for bucket CORS configuration (issues #35, #79, #87)."""
+
+import json
+
+import pytest
+
+from cng_datasets.storage.s3 import CORS_EXPOSE_HEADERS, S3Manager
+
+# Headers a browser must be allowed to read cross-origin for HTTP Range-based
+# rendering of PMTiles and COGs. Accept-Ranges/Content-Range are not
+# CORS-safelisted, so they must be exposed explicitly.
+REQUIRED_RANGE_HEADERS = {
+    "ETag",
+    "Content-Length",
+    "Content-Type",
+    "Accept-Ranges",
+    "Content-Range",
+}
+
+
+class _FakeS3Client:
+    """Captures the CORSConfiguration handed to put_bucket_cors."""
+
+    def __init__(self):
+        self.cors_configuration = None
+
+    def put_bucket_cors(self, Bucket=None, CORSConfiguration=None):  # noqa: N803
+        self.cors_configuration = CORSConfiguration
+
+
+@pytest.mark.timeout(5)
+def test_expose_headers_constant_covers_range_headers():
+    assert REQUIRED_RANGE_HEADERS.issubset(set(CORS_EXPOSE_HEADERS))
+
+
+@pytest.mark.timeout(5)
+def test_s3manager_configure_cors_exposes_range_headers():
+    """The boto3 path (storage cors) must expose the range headers (#35)."""
+    manager = S3Manager(endpoint_url="https://example.com")
+    fake = _FakeS3Client()
+    manager._client = fake  # bypass the lazy boto3 client
+
+    manager.configure_cors("my-bucket")
+
+    rule = fake.cors_configuration["CORSRules"][0]
+    assert REQUIRED_RANGE_HEADERS.issubset(set(rule["ExposeHeaders"]))
+
+
+@pytest.mark.timeout(5)
+def test_setup_public_bucket_exposes_range_headers(monkeypatch):
+    """The aws-cli path (setup-bucket) must expose the range headers (#79, #87)."""
+    from cng_datasets.storage import setup_bucket
+
+    captured = {}
+
+    class _Result:
+        returncode = 0
+        stdout = ""
+        stderr = ""
+
+    def fake_run(cmd, *args, **kwargs):
+        if "put-bucket-cors" in cmd:
+            captured["cors"] = cmd[cmd.index("--cors-configuration") + 1]
+        return _Result()
+
+    monkeypatch.setattr(setup_bucket.subprocess, "run", fake_run)
+    monkeypatch.setenv("AWS_ACCESS_KEY_ID", "test")
+    monkeypatch.setenv("AWS_SECRET_ACCESS_KEY", "test")
+
+    ok = setup_bucket.setup_public_bucket(
+        bucket_name="my-bucket", endpoint="example.com", verbose=False
+    )
+    assert ok
+    cors = json.loads(captured["cors"])
+    expose = cors["CORSRules"][0]["ExposeHeaders"]
+    assert REQUIRED_RANGE_HEADERS.issubset(set(expose))
+
+
+@pytest.mark.timeout(5)
+def test_both_paths_share_one_expose_header_list():
+    """Both CORS code paths reference the same constant so they cannot drift."""
+    from cng_datasets.storage import setup_bucket
+
+    assert setup_bucket.CORS_EXPOSE_HEADERS is CORS_EXPOSE_HEADERS
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])


### PR DESCRIPTION
Fixes #87. Fixes #79. Fixes #35.

## Problem

PMTiles tile fetches and COG byte-range reads require the browser to read `Accept-Ranges` and `Content-Range` cross-origin. Neither is a [CORS-safelisted response header](https://developer.mozilla.org/en-US/docs/Glossary/CORS-safelisted_response_header), so without explicit `Access-Control-Expose-Headers` a JavaScript client cannot see them — range reads fail in the browser even though `curl` works.

Two CORS code paths had drifted apart, which is why this got filed three times:
- `S3Manager.configure_cors` (the `storage cors` command) set **no `ExposeHeaders` at all** (#35).
- `setup_public_bucket` (the `setup-bucket` command) exposed only `ETag, Content-Type, Content-Disposition` — missing the range headers (#87, #79).

## Fix

Define the correct expose-header set once as `s3.CORS_EXPOSE_HEADERS` and reference it from both paths so they can't drift again:

```python
CORS_EXPOSE_HEADERS = ["ETag", "Content-Length", "Content-Type", "Accept-Ranges", "Content-Range"]
```

This matches the known-good `public-padus` bucket (verified live). Tests cover both code paths plus a guard that they share the one list.

## Verification notes (I checked the claims rather than trusting the issue text)

- **MDN/Fetch spec:** `Content-Length` *is* safelisted; `Accept-Ranges` and `Content-Range` are **not** — confirming explicit exposure is required.
- **PMTiles.js source:** it *does* read `resp.headers.get("Content-Range")` (throws `"Missing content-length on 416 response"` when absent), though that path triggers only for archives < 16 KB. For large archives it leans on `Content-Length` + the body.
- **COG clients (geotiff.js):** range reads over HTTPS genuinely need these headers exposed — the clearest justification (#79's COG framing).

**Correction to #35:** its central claim — that pmtiles.js "does not parse `Content-Range` or `Accept-Ranges`" and so this is "minor hygiene, not a blocker" — is **inaccurate**. PMTiles.js does read `Content-Range`, and COG clients depend on these headers. The fix is correctness, not hygiene. The exact cause of #87's large-PMTiles silent failure may also have involved the previously-missing `Content-Length` exposure / Ceph RGW behavior; it can't be reproduced now since all `public-*` buckets were manually patched, but the corrected set is the right destination regardless.

🤖 Generated with [Claude Code](https://claude.com/claude-code)