### PR TITLE
fix(#77): export TIPPECANOE_MAX_THREADS in the PMTiles job

### DIFF
--- a/cng_datasets/k8s/workflows.py
+++ b/cng_datasets/k8s/workflows.py
@@ -1290,7 +1290,10 @@ ogr2ogr -wrapdateline -datelineoffset 15 -f GeoJSONSeq /tmp/$DATASET.geojsonl /v
 # non-power-of-2 logical CPU counts which triggers an internal assertion
 # failure "N shards not a power of 2" (felt/tippecanoe#216).
 # Round detected CPU count down to nearest power of 2 to preserve I/O parallelism.
-TIPPECANOE_MAX_THREADS=$(python3 -c "import os; n=os.cpu_count() or 1; print(1<<(n.bit_length()-1))")
+# Must be `export`ed: tippecanoe is a child process and reads this from the
+# environment, not the shell. A plain assignment is invisible to it, so it
+# falls back to the raw (non-power-of-2) CPU count and crashes (issue #77).
+export TIPPECANOE_MAX_THREADS=$(python3 -c "import os; n=os.cpu_count() or 1; print(1<<(n.bit_length()-1))")
 tippecanoe -o /tmp/$DATASET.pmtiles -l $DATASET --drop-densest-as-needed --extend-zooms-if-still-dropping --force /tmp/$DATASET.geojsonl
 
 # Upload to S3 using rclone

--- a/tests/test_k8s_workflows.py
+++ b/tests/test_k8s_workflows.py
@@ -225,6 +225,24 @@ class TestWorkflowGeneration:
             assert "-wrapdateline" in command_str
             assert "-datelineoffset 15" in command_str
 
+    def test_pmtiles_job_exports_tippecanoe_max_threads(self):
+        """TIPPECANOE_MAX_THREADS must be exported so the child tippecanoe sees it (#77)."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            generate_dataset_workflow(
+                dataset_name="test-ds",
+                source_url="https://s3-west.nrp-nautilus.io/public-test/fixtures/test-fixture.gpkg",
+                bucket="test-bucket",
+                output_dir=tmpdir,
+            )
+
+            pmtiles_file = Path(tmpdir) / "test-ds-pmtiles.yaml"
+            with open(pmtiles_file) as f:
+                job = yaml.safe_load(f)
+
+            command = job["spec"]["template"]["spec"]["containers"][0]["command"][2]
+            # A plain (un-exported) assignment is invisible to the child process.
+            assert "export TIPPECANOE_MAX_THREADS=" in command
+
     @pytest.mark.timeout(5)
     def test_workflow_rbac(self):
         """Test RBAC configuration is generated."""


### PR DESCRIPTION
Fixes #77.

## Problem

The generated PMTiles job assigned `TIPPECANOE_MAX_THREADS` as a **shell-local** variable:

```bash
TIPPECANOE_MAX_THREADS=$(python3 -c "...print(1<<(n.bit_length()-1))")
tippecanoe -o /tmp/$DATASET.pmtiles ...
```

`tippecanoe` is a child process and reads `TIPPECANOE_MAX_THREADS` from the **environment**, not the parent shell. Without `export` it never sees the value, falls back to `std::thread::hardware_concurrency()`, and on a node with a non-power-of-2 logical CPU count (observed: 745-CPU `node-2-9.sdsc.optiputer.net`) crashes immediately with `Internal error: 745 shards not a power of 2` — right after a successful `ogr2ogr` step.

## Fix

`export` the variable so it crosses into the child environment. The power-of-2 rounding logic is unchanged. Added a regression test asserting the generated command exports it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)