### PR TITLE
test: stop workflow-generation tests from hitting the network

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -82,4 +82,5 @@ markers = [
     "slow: marks tests as slow (deselect with '-m \"not slow\"')",
     "integration: marks tests as integration tests (deselect with '-m \"not integration\"')",
     "timeout: marks tests with timeout values (provided by pytest-timeout plugin)",
+    "realnetwork: opt out of the autouse source-introspection stub and hit the real network",
 ]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,35 @@
+"""Shared pytest fixtures.
+
+The main job here is to keep workflow-generation tests off the network.
+``generate_dataset_workflow`` introspects the source file by shelling out to
+``ogrinfo`` (via ``_count_source_features`` and ``_detect_geometry_type``).
+Most tests pass a remote fixture URL, so those calls reach across the network;
+when the NRP endpoint is slow they hang past the 10 s pytest timeout and flake
+CI (PRs #109–#111 each burned reruns on exactly this). Stub both with
+deterministic defaults so generation logic is exercised without any I/O.
+"""
+
+import pytest
+
+
+@pytest.fixture(autouse=True)
+def stub_source_introspection(request, monkeypatch):
+    """Replace the network-touching source-introspection helpers with stubs.
+
+    Tests that need a specific feature count already re-patch
+    ``_count_source_features`` in their own body, and that override wins
+    (it runs after this fixture). No test exercises the real detectors, so
+    deterministic defaults are safe; a test can still opt back into the real
+    implementations with ``@pytest.mark.realnetwork``.
+    """
+    if request.node.get_closest_marker("realnetwork"):
+        return
+    try:
+        import cng_datasets.k8s.workflows as wf
+    except Exception:
+        return
+    # 5 matches the canonical test fixture (test-fixture.gpkg, 5 features), so
+    # the chunking-math tests that count it get the same answer offline. Tests
+    # needing a different count re-patch in their own body (that override wins).
+    monkeypatch.setattr(wf, "_count_source_features", lambda *a, **k: 5, raising=False)
+    monkeypatch.setattr(wf, "_detect_geometry_type", lambda *a, **k: "polygon", raising=False)


### PR DESCRIPTION
## Problem

`generate_dataset_workflow` introspects the source file by shelling out to `ogrinfo` (via `_count_source_features` and `_detect_geometry_type`). Most workflow-generation tests pass a remote fixture URL, so those calls cross the network to the NRP S3 endpoint. When the endpoint is slow the subprocess hangs past the 10 s pytest timeout and the whole `test` job fails.

This flaked CI repeatedly — PRs #109, #110, and #111 each needed reruns — with the failing test varying by whichever network call happened to be slow that run (`test_workflow_command`, `test_custom_s3_secret_name`, …). The tracebacks all bottomed out in `subprocess.run(... timeout=30)` inside `_detect_geometry_type` / `_count_source_features`.

## Fix

Add `tests/conftest.py` with an autouse fixture that stubs both helpers with deterministic defaults, so generation logic is exercised with **zero network I/O**:
- `_count_source_features → 5` (matches the canonical `test-fixture.gpkg`, 5 features, so the chunking-math tests get the same answer offline)
- `_detect_geometry_type → "polygon"`

The three tests that already re-patch `_count_source_features` with `mocker` keep working — their in-body override runs after the fixture and wins. A `realnetwork` marker (registered in `pyproject.toml`) opts a test back into the real implementations if a genuine integration test is ever wanted.

## Verification

Locally (no network), `test_k8s_workflows.py` goes from 47→52 passing with the previously-flaky `test_hex_job_chunked` / `test_hex_job_real_bucket` and the `mocker`-override tests all green; the remaining local failures are solely the pre-existing missing-`osgeo` paths (they pass in CI's GDAL image). Lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)