### PR TITLE
fix(#104): preserve sub-H3-cell polygons via representative-point fallback

### DIFF
--- a/cng_datasets/vector/h3_tiling.py
+++ b/cng_datasets/vector/h3_tiling.py
@@ -173,6 +173,17 @@ def geom_to_h3_cells(
     # Convert to multi-polygons and unnest, then generate H3 cells
     # The geometry is already GEOMETRY type in DuckDB spatial extension
     # Line geometries are buffered into polygons before polyfill.
+    #
+    # Any polygon smaller than one H3 cell at this resolution contains no cell
+    # centre, so h3_polygon_wkt_to_cells returns an empty array and the feature
+    # would vanish from the output entirely; a chunk in which every feature is
+    # sub-cell produces no rows at all (issue #104). When the polyfill is empty
+    # we fall back to the single cell containing the feature's ST_PointOnSurface
+    # — a guaranteed-interior representative point — so every feature yields
+    # >= 1 cell regardless of its size. The fallback is gated on a valid latitude
+    # range: a polygon with empty polyfill AND out-of-range Y is left empty on
+    # purpose so the downstream swapped-(lat,lon) check still raises a clear
+    # error rather than feeding an invalid latitude into h3_latlng_to_cell.
     sql = f'''
         WITH t0 AS (
             SELECT {col_list},
@@ -189,14 +200,28 @@ def geom_to_h3_cells(
             SELECT {col_list},
                    UNNEST(ST_Dump(geom)).geom AS geom
             FROM t0
+        ),
+        t2 AS (
+            SELECT {col_list},
+                   geom,
+                   CASE
+                       WHEN ST_GeometryType(geom) = 'POINT'
+                       THEN [h3_latlng_to_cell(ST_Y(geom), ST_X(geom), {zoom})]
+                       ELSE h3_polygon_wkt_to_cells(ST_AsText(ST_Force2D(geom)), {zoom})
+                   END AS h3id
+            FROM t1
         )
         SELECT {col_list},
                CASE
-                   WHEN ST_GeometryType(geom) = 'POINT'
-                   THEN [h3_latlng_to_cell(ST_Y(geom), ST_X(geom), {zoom})]
-                   ELSE h3_polygon_wkt_to_cells(ST_AsText(ST_Force2D(geom)), {zoom})
+                   WHEN h3id IS NOT NULL AND len(h3id) > 0 THEN h3id
+                   WHEN ST_YMin(geom) >= -90 AND ST_YMax(geom) <= 90
+                   THEN [h3_latlng_to_cell(
+                            ST_Y(ST_PointOnSurface(geom)),
+                            ST_X(ST_PointOnSurface(geom)),
+                            {zoom})]
+                   ELSE h3id
                END AS h3id
-        FROM t1
+        FROM t2
     '''
 
     return sql
@@ -409,12 +434,15 @@ class H3VectorProcessor:
         """)
 
         # Check for features that produced 0 H3 cells despite having polygon area.
-        # Two distinct causes:
-        #   1. Swapped (lat, lon) coordinates → Y values outside valid lat range [-90, 90]
-        #      → raise RuntimeError (bad input data)
-        #   2. Polygon smaller than a single H3 cell at the target resolution
-        #      → valid input, just warn and continue
-        # Join intermediate file (has id + h3id) back to chunk_table (has id + geom).
+        # With the ST_PointOnSurface fallback (issue #104) a valid sub-cell
+        # polygon now always yields >= 1 cell, so the only remaining cause of an
+        # empty array on an area>0, valid-latitude polygon is removed. What stays
+        # detectable here is swapped (lat, lon) input: those have Y outside the
+        # valid latitude range, the fallback is deliberately NOT applied (it
+        # would feed an invalid latitude into h3_latlng_to_cell), the array stays
+        # empty, and we raise a clear RuntimeError. Any other residual empty
+        # array (degenerate geometry the fallback could not represent) is just
+        # warned about. Join intermediate (id + h3id) back to chunk_table (id + geom).
         swapped, small = self.con.execute(f"""
             SELECT
                 COUNT(*) FILTER (
@@ -440,8 +468,8 @@ class H3VectorProcessor:
         if small > 0:
             print(
                 f"  Warning: {small} polygon feature(s) in chunk {chunk_id} produced 0 H3 cells "
-                f"at resolution {self.h3_resolution} — polygons are smaller than one H3 cell "
-                f"and will be skipped."
+                f"at resolution {self.h3_resolution} even after the representative-point "
+                f"fallback — likely degenerate geometry. These features are dropped."
             )
 
         print(f"  ✓ Pass 1 complete: {intermediate_file}")

--- a/tests/test_vector.py
+++ b/tests/test_vector.py
@@ -281,9 +281,55 @@ class TestH3Functions:
         assert 'id' in result.columns
         assert 'name' in result.columns
         assert result['name'].iloc[0] == 'test'
-        
+
         con.close()
-    
+
+    @pytest.mark.timeout(10)
+    def test_subcell_polygon_gets_representative_cell(self):
+        """A polygon smaller than one H3 cell falls back to one representative cell (#104)."""
+        con = setup_duckdb_connection()
+        # ~50 m x 50 m polygon, far smaller than a res-8 cell (~0.74 km²).
+        con.execute("""
+            CREATE TABLE tiny AS
+            SELECT 1::BIGINT AS _cng_fid,
+                   ST_GeomFromText('POLYGON((10.00010 10.00010,10.00060 10.00010,10.00060 10.00060,10.00010 10.00060,10.00010 10.00010))') AS geom
+        """)
+        sql = geom_to_h3_cells(con, "tiny", zoom=8)
+        n = con.execute(f"SELECT len(h3id) FROM ({sql})").fetchone()[0]
+        con.close()
+        assert n == 1, f"sub-cell polygon should yield one fallback cell, got {n}"
+
+    @pytest.mark.timeout(10)
+    def test_subcell_multipolygon_part_preserved(self):
+        """A sub-cell MULTIPOLYGON part is preserved via the fallback, not dropped (#104)."""
+        con = setup_duckdb_connection()
+        con.execute("""
+            CREATE TABLE tinymp AS
+            SELECT 1::BIGINT AS _cng_fid,
+                   ST_GeomFromText('MULTIPOLYGON(((10.0001 10.0001,10.0006 10.0001,10.0006 10.0006,10.0001 10.0006,10.0001 10.0001)))') AS geom
+        """)
+        sql = geom_to_h3_cells(con, "tinymp", zoom=8)
+        n = con.execute(f"SELECT len(h3id) FROM ({sql})").fetchone()[0]
+        con.close()
+        assert n >= 1
+
+    @pytest.mark.timeout(10)
+    def test_swapped_coordinate_polygon_stays_empty(self):
+        """The fallback is gated on valid latitude: swapped (lat,lon) input stays
+        empty so the downstream swapped-coordinate check still raises (#104)."""
+        con = setup_duckdb_connection()
+        # Y values (~122) are outside H3's valid latitude range, so the fallback
+        # must NOT fire (it would feed an invalid latitude into h3_latlng_to_cell).
+        con.execute("""
+            CREATE TABLE swapped AS
+            SELECT 1::BIGINT AS _cng_fid,
+                   ST_GeomFromText('POLYGON((10 122.0001,10.0005 122.0001,10.0005 122.0006,10 122.0006,10 122.0001))') AS geom
+        """)
+        sql = geom_to_h3_cells(con, "swapped", zoom=8)
+        n = con.execute(f"SELECT len(h3id) FROM ({sql})").fetchone()[0]
+        con.close()
+        assert n == 0, "swapped-coordinate polygon must stay empty for the QC to catch it"
+
     @pytest.mark.timeout(5)
     def test_h3_parent_resolution(self):
         """Test H3 parent cell calculation."""
@@ -771,17 +817,19 @@ class TestSwappedCoordinateDetection:
             processor.con.close()
 
     @pytest.mark.timeout(60)
-    def test_small_polygon_warns_not_raises(self):
+    def test_small_polygon_preserved_via_representative_point(self):
         """
-        Polygons smaller than one H3 cell at the target resolution should produce 0
-        cells but NOT raise a RuntimeError (issue #51).  The chunk should still
-        succeed and the processor should print a warning.
+        Polygons smaller than one H3 cell must NOT be dropped (issue #104,
+        superseding the earlier #51 skip-with-warning behavior). The H3 polyfill
+        returns no cells for a sub-cell polygon, so each feature falls back to
+        the single cell containing its ST_PointOnSurface — every feature yields
+        >= 1 row, and an all-sub-cell chunk still writes output (no Pass 2 crash).
         """
         with tempfile.TemporaryDirectory() as tmpdir:
             con = setup_duckdb_connection()
             test_parquet = f"{tmpdir}/test.parquet"
-            # A tiny polygon (~0.0001 km²) in correct (lon, lat) order.
-            # At H3 resolution 8 (cell area ~0.74 km²) this produces 0 cells.
+            # Three tiny polygons (~0.0001 km²) in correct (lon, lat) order.
+            # At H3 resolution 8 (cell area ~0.74 km²) the polyfill is empty.
             con.execute(f"""
                 CREATE TABLE test_data AS
                 SELECT
@@ -801,12 +849,16 @@ class TestSwappedCoordinateDetection:
                 h3_resolution=8,
                 chunk_size=10,
             )
-            # Must not raise — small polygons should be skipped with a warning
+            # Must not raise, and the all-sub-cell chunk must still produce output.
             output_file = processor.process_chunk(0)
-            processor.con.close()
-            # Output file is created (may be empty if all features are skipped,
-            # but the process must complete without error)
             assert output_file is not None
+            # Every sub-cell feature is preserved with exactly one fallback cell.
+            n_rows, n_features = processor.con.execute(
+                f"SELECT COUNT(*), COUNT(DISTINCT id) FROM read_parquet('{output_file}')"
+            ).fetchone()
+            processor.con.close()
+            assert n_features == 3, "all three sub-cell features must survive"
+            assert n_rows == 3, "each sub-cell feature maps to exactly one cell"
 
 
 class TestRepartitionWithAttributeJoin:


### PR DESCRIPTION
Fixes #104.

## Problem (generic)

`geom_to_h3_cells()` — the general polygon→H3 tiling used by **every** vector dataset — drops any polygon smaller than one H3 cell at the target resolution. Such a polygon contains no cell centre, so `h3_polygon_wkt_to_cells` returns an empty array and the feature produces zero rows and vanishes from the hex output. Worse, a chunk in which *every* feature is sub-cell writes no intermediate file and crashes Pass 2.

This is a generic tiling-engine bug, not dataset-specific; WDPA (June 2026) was simply where it surfaced — ~113k of 306,985 features were silently lost.

## Fix (generic, source-only)

When the polyfill is empty for a feature, fall back to the single cell containing the feature's `ST_PointOnSurface` — a guaranteed-interior representative point — so **every feature yields ≥ 1 cell regardless of size**, and an all-sub-cell chunk still produces output.

The fallback is gated on a valid latitude range: a polygon whose polyfill is empty **and** whose Y is outside `[-90, 90]` is left empty on purpose, so the existing swapped-`(lat,lon)` detection still raises a clear `RuntimeError` instead of feeding an invalid latitude into `h3_latlng_to_cell`.

The change is entirely in `cng_datasets/vector/h3_tiling.py` (the library SQL builder). No dataset-specific logic, workflow YAML, or per-dataset config — purely a behavior fix to the stock tiling path. This is the upstream landing spot that lets data-workflows drop its bespoke `ST_PointOnSurface` job and return to the stock pipeline (per the issue).

Adaptive-by-area resolution (the issue's optional ask) is intentionally **out of scope** and left to #98.

## Tests

SQL-level regression tests for: a sub-cell polygon (→ 1 fallback cell), a sub-cell MULTIPOLYGON part (preserved), and the gated swapped-coordinate case (stays empty so QC catches it). The former #51 small-polygon test is rewritten to assert preservation (≥ 1 row per feature, all-sub-cell chunk still writes output) rather than skipping. Full `test_vector.py` (40 tests) passes locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)