### PR TITLE
fix(#102,#103): UBIGINT hex-column assertion + intra-partition _cng_fid ordering

### DIFF
--- a/cng_datasets/hex_checks.py
+++ b/cng_datasets/hex_checks.py
@@ -1,0 +1,63 @@
+"""Post-build invariants for H3-indexed (hex) datasets.
+
+These are schema-only assertions run after the hex write step (vector
+repartition and raster hex) to fail fast on a corrupt build rather than
+silently shipping a dataset that breaks downstream consumers.
+"""
+
+from typing import Callable, List, Tuple
+
+
+def assert_h3_columns_unsigned(
+    fetch: Callable[[str], List[Tuple]],
+    hex_glob: str,
+) -> None:
+    """Assert every physical H3 index column ``h{N>=1}`` reads back as ``UBIGINT``.
+
+    Native-cell columns (``h3_polygon_wkt_to_cells`` / ``h3_latlng_to_cell``)
+    are always ``UBIGINT``, but ``h3_cell_to_parent`` changed its return type
+    from signed ``BIGINT`` to ``UBIGINT`` in a newer h3 community-extension
+    release. Because both the pipeline and the MCP do *unpinned*
+    ``INSTALL h3 FROM community``, a dataset's parent-column sign would
+    otherwise be a fossil of the extension version on its build date. We keep
+    tracking the latest h3, so this is an assertion (fail the build) rather
+    than a version pin — it also catches a bespoke ingest that casts the native
+    cell column (e.g. a ``BIGINT`` native ``h6``).
+
+    ``h0`` is exempt: it is the Hive partition key, so DuckDB infers its type
+    from the directory string and always reads it back as signed ``BIGINT``
+    regardless of the physical type. The convention is therefore: physical
+    h-cols ``UBIGINT``; ``h0`` the signed hive key.
+
+    The check is schema-only (``DESCRIBE``, no data scan) and is evaluated
+    through the same path the consumer reads (the hive glob), so it sees the
+    types consumers actually get.
+
+    Args:
+        fetch: Callable that runs a SQL string and returns the result rows as a
+            list of tuples. Pass ``lambda sql: con.raw_sql(sql).fetchall()`` for
+            an ibis DuckDB connection, or ``lambda sql: con.execute(sql).fetchall()``
+            for a raw ``duckdb`` connection.
+        hex_glob: A ``read_parquet``-compatible path/glob for the written hex
+            output (e.g. ``s3://bucket/foo/hex/h0=*/data_0.parquet``).
+
+    Raises:
+        RuntimeError: if any ``h{N>=1}`` column is not ``UBIGINT``. See issue #102.
+    """
+    sql = (
+        "SELECT column_name, column_type FROM "
+        f"(DESCRIBE SELECT * FROM read_parquet('{hex_glob}')) "
+        "WHERE column_name SIMILAR TO 'h[1-9][0-9]*' "
+        "AND column_type <> 'UBIGINT'"
+    )
+    offenders = fetch(sql)
+    if offenders:
+        cols = ", ".join(f"{name} ({typ})" for name, typ in offenders)
+        raise RuntimeError(
+            "H3 index columns must be UBIGINT after the hex build "
+            "(h0 is exempt as the signed hive key), but found non-UBIGINT "
+            f"columns: {cols}. This usually means the h3 community extension "
+            "emitted signed BIGINT parents (an older h3_cell_to_parent) or an "
+            "ingest cast the native cell column. Rebuild with a current h3 "
+            "extension or recast the offending columns to UBIGINT. See issue #102."
+        )

--- a/cng_datasets/raster/cog.py
+++ b/cng_datasets/raster/cog.py
@@ -11,6 +11,7 @@ import math
 import tempfile
 import duckdb
 from osgeo import gdal, osr
+from cng_datasets.hex_checks import assert_h3_columns_unsigned
 from cng_datasets.storage.s3 import configure_s3_credentials
 
 
@@ -1427,6 +1428,14 @@ class RasterProcessor:
             ) TO '{output_path}' (FORMAT PARQUET, COMPRESSION 'zstd')
         """)
         self.con.unregister("hex_values")
+
+        # Fail fast if the h3 extension emitted signed BIGINT parents (issue #102):
+        # the native cell column is UBIGINT, but h3_cell_to_parent's return type
+        # depends on the (unpinned) extension version. Assert per-partition since
+        # each h0 region is written by an independent job.
+        assert_h3_columns_unsigned(
+            lambda sql: self.con.execute(sql).fetchall(), output_path
+        )
 
         print(f"  ✓ Wrote: {output_path} ({len(results)} cells)")
         return output_path

--- a/cng_datasets/vector/repartition.py
+++ b/cng_datasets/vector/repartition.py
@@ -10,6 +10,7 @@ import shutil
 import subprocess
 import duckdb
 import ibis
+from cng_datasets.hex_checks import assert_h3_columns_unsigned
 from cng_datasets.storage.s3 import configure_s3_credentials
 
 
@@ -164,8 +165,15 @@ def repartition_by_h0(
         os.makedirs(local_partition, exist_ok=True)
         local_file = os.path.join(local_partition, 'data_0.parquet')
 
+        # ORDER BY the row id within each h0 partition (issue #103) so parquet
+        # row-group zonemaps can prune by feature identity: a plain
+        # `WHERE _cng_fid IN (...)` then skips the partitions/row-groups whose
+        # [min,max] excludes the targets instead of scanning every row. Wrap in
+        # a subquery so ORDER BY references the unambiguous output column (the
+        # join exposes the id on both sides). PARTITION BY h0 is unchanged.
         con.raw_sql(
-            f"COPY ({join_sql.format(h0=h0)}) TO '{local_file}'"
+            f"COPY (SELECT * FROM ({join_sql.format(h0=h0)})"
+            f" ORDER BY \"{chunk_id_col}\") TO '{local_file}'"
             f" (FORMAT PARQUET, COMPRESSION ZSTD)"
         )
 
@@ -190,6 +198,13 @@ def repartition_by_h0(
             f"No partitions written — all chunks appear to be empty. "
             f"Check that the hex job in '{chunks_dir}' produced non-empty output."
         )
+
+    # Assert H3 index columns are UBIGINT through the consumer (hive glob) path,
+    # before cleaning up the chunks. Raises on a non-UBIGINT h{N>=1} column
+    # (issue #102), leaving chunks intact for debugging if it fails.
+    hex_glob = f"{output_dir.rstrip('/')}/h0=*/data_0.parquet"
+    print(f'Asserting H3 columns are UBIGINT via {hex_glob}...')
+    assert_h3_columns_unsigned(lambda sql: con.raw_sql(sql).fetchall(), hex_glob)
 
     print('Cleaning up local directory...')
     shutil.rmtree(local_dir, ignore_errors=True)

--- a/tests/test_hex_checks.py
+++ b/tests/test_hex_checks.py
@@ -1,0 +1,88 @@
+"""Tests for post-build hex invariants (issue #102)."""
+
+import os
+import tempfile
+
+import duckdb
+import pytest
+
+from cng_datasets.hex_checks import assert_h3_columns_unsigned
+
+
+def _fetch(con):
+    return lambda sql: con.execute(sql).fetchall()
+
+
+def _write(con, path, select):
+    con.execute(f"COPY ({select}) TO '{path}' (FORMAT PARQUET)")
+
+
+class TestAssertH3ColumnsUnsigned:
+    def test_passes_when_all_h_columns_ubigint(self):
+        """UBIGINT native + parent columns satisfy the invariant."""
+        with tempfile.TemporaryDirectory() as tmp:
+            con = duckdb.connect()
+            path = os.path.join(tmp, "data_0.parquet")
+            _write(
+                con,
+                path,
+                "SELECT 1.5 AS value, "
+                "613196575302221823::UBIGINT AS h10, "
+                "599718724986109951::UBIGINT AS h8, "
+                "577199624117288959 AS h0",
+            )
+            # Should not raise.
+            assert_h3_columns_unsigned(_fetch(con), path)
+            con.close()
+
+    def test_raises_on_signed_bigint_parent(self):
+        """A signed BIGINT h-column (old h3_cell_to_parent) fails the build."""
+        with tempfile.TemporaryDirectory() as tmp:
+            con = duckdb.connect()
+            path = os.path.join(tmp, "data_0.parquet")
+            _write(
+                con,
+                path,
+                "SELECT 1.5 AS value, "
+                "613196575302221823::UBIGINT AS h10, "
+                "599718724986109951::BIGINT AS h8, "  # offender
+                "577199624117288959 AS h0",
+            )
+            with pytest.raises(RuntimeError, match=r"h8 \(BIGINT\)"):
+                assert_h3_columns_unsigned(_fetch(con), path)
+            con.close()
+
+    def test_h0_exempt_when_read_as_bigint(self):
+        """h0 is the hive key (read back as BIGINT) and must not trip the check."""
+        with tempfile.TemporaryDirectory() as tmp:
+            con = duckdb.connect()
+            # Hive-partitioned layout so h0 is inferred from the path as BIGINT.
+            part = os.path.join(tmp, "h0=577199624117288959")
+            os.makedirs(part)
+            _write(
+                con,
+                os.path.join(part, "data_0.parquet"),
+                "SELECT 1.5 AS value, 613196575302221823::UBIGINT AS h10",
+            )
+            glob = os.path.join(tmp, "h0=*/data_0.parquet")
+            assert con.execute(
+                f"SELECT typeof(h0) FROM read_parquet('{glob}') LIMIT 1"
+            ).fetchone()[0] == "BIGINT"
+            # h0 BIGINT must be ignored; only h{N>=1} are checked.
+            assert_h3_columns_unsigned(_fetch(con), glob)
+            con.close()
+
+    def test_value_columns_named_like_h_are_not_matched(self):
+        """A non-index column such as 'h2o' or 'height' must not be flagged."""
+        with tempfile.TemporaryDirectory() as tmp:
+            con = duckdb.connect()
+            path = os.path.join(tmp, "data_0.parquet")
+            _write(
+                con,
+                path,
+                "SELECT 1.5 AS height, 'x' AS h2o, "
+                "613196575302221823::UBIGINT AS h8, "
+                "577199624117288959 AS h0",
+            )
+            assert_h3_columns_unsigned(_fetch(con), path)
+            con.close()

--- a/tests/test_vector.py
+++ b/tests/test_vector.py
@@ -924,9 +924,9 @@ class TestRepartitionWithAttributeJoin:
                 CREATE TABLE chunk_data AS 
                 SELECT 
                     1 as MyID,
-                    613196575302221823 as h10,
-                    613196575302221823 as h9,
-                    613196575302221823 as h8,
+                    613196575302221823::UBIGINT as h10,
+                    613196575302221823::UBIGINT as h9,
+                    613196575302221823::UBIGINT as h8,
                     577199624117288959 as h0
             """)
             con.execute(f"COPY chunk_data TO '{chunks_dir}/chunk_000000.parquet' (FORMAT PARQUET)")
@@ -1023,9 +1023,9 @@ class TestRepartitionWithAttributeJoin:
                 CREATE TABLE chunk_data AS 
                 SELECT 
                     i as fid,
-                    613196575302221823 + i as h10,
-                    613196575302221823 as h9,
-                    613196575302221823 as h8,
+                    (613196575302221823 + i)::UBIGINT as h10,
+                    613196575302221823::UBIGINT as h9,
+                    613196575302221823::UBIGINT as h8,
                     577199624117288959 as h0
                 FROM range(10) t(i)
             """)
@@ -1053,7 +1053,54 @@ class TestRepartitionWithAttributeJoin:
             assert len(output_df) == 10
             
             con.close()
-    
+
+    @pytest.mark.timeout(15)
+    def test_repartition_orders_by_cng_fid_within_partition(self):
+        """Rows within each h0 partition are sorted by _cng_fid (issue #103).
+
+        The intra-partition ORDER BY tightens row-group [min,max] zonemaps so a
+        `WHERE _cng_fid IN (...)` can prune. We assert the physical row order is
+        non-decreasing in _cng_fid even when the chunk input is shuffled.
+        """
+        with tempfile.TemporaryDirectory() as tmpdir:
+            con = setup_duckdb_connection()
+            chunks_dir = f"{tmpdir}/chunks"
+            os.makedirs(chunks_dir, exist_ok=True)
+
+            # Single h0 partition; _cng_fid deliberately out of order, multiple
+            # rows per fid (the hex explosion) so ordering is observable.
+            con.execute(f"""
+                CREATE TABLE chunk_data AS
+                SELECT
+                    _cng_fid,
+                    (613196575302221823 + row_number() OVER ())::UBIGINT as h10,
+                    613196575302221823::UBIGINT as h8,
+                    577199624117288959 as h0
+                FROM (VALUES (5),(1),(3),(1),(5),(2),(3)) t(_cng_fid)
+            """)
+            con.execute(f"COPY chunk_data TO '{chunks_dir}/chunk_000000.parquet' (FORMAT PARQUET)")
+            con.close()
+
+            os.environ['AWS_ACCESS_KEY_ID'] = ''
+            os.environ['AWS_SECRET_ACCESS_KEY'] = ''
+
+            repartition_by_h0(
+                chunks_dir=chunks_dir,
+                output_dir=f"{tmpdir}/output",
+                source_parquet=None,
+                cleanup=False,
+            )
+
+            con = setup_duckdb_connection()
+            part = f"{tmpdir}/output/h0=577199624117288959/data_0.parquet"
+            # Read in physical (file) order — no ORDER BY in the query.
+            fids = [r[0] for r in con.execute(
+                f"SELECT _cng_fid FROM read_parquet('{part}')"
+            ).fetchall()]
+            con.close()
+
+            assert fids == sorted(fids), f"rows not ordered by _cng_fid: {fids}"
+
     @pytest.mark.timeout(15)
     def test_repartition_with_mixed_case_columns(self):
         """Test that mixed case ID columns are handled correctly."""


### PR DESCRIPTION
Implements the first item in the #114 roadmap (**#102 + #103 together** — same hex-write path, low risk / high value).

## #103 — `ORDER BY _cng_fid` within each h0 partition
`repartition_by_h0` now sorts each `h0` partition file by the row id before writing. `PARTITION BY h0` is unchanged — this is a **pure intra-file reorder**, so schema, paths, values, and partition layout are all identical. The payoff: parquet row-group zonemaps can prune by feature identity, so a plain `WHERE _cng_fid IN (...)` skips the partitions/row-groups whose `[min,max]` excludes the targets instead of scanning every row (the 107-files / 128M-rows / 39.8s case in #103). The `COPY` wraps the existing join in a subquery so `ORDER BY` binds to the unambiguous output column.

## #102 — assert physical H3 columns are UBIGINT
New shared helper `cng_datasets/hex_checks.py::assert_h3_columns_unsigned()` fails the build if any physical `h{N≥1}` column is not `UBIGINT`. `h0` is exempt (it's the signed hive partition key, always read back as `BIGINT`). This catches:
- a signed-`BIGINT` `h3_cell_to_parent` from an older, **unpinned** `INSTALL h3 FROM community` (per the catalog audit), and
- a bespoke ingest that casts the native cell column (e.g. GFW's `BIGINT` `h6`).

It's an assertion, not a version pin — we keep tracking the latest h3. Schema-only (`DESCRIBE`, no data scan), evaluated through the **consumer hive-glob path** so it sees the types consumers actually get. Wired into:
- **vector** `repartition.py` — after all partitions are written, before chunk cleanup (failure leaves chunks intact for debugging);
- **raster** `cog.py` — per-`h0` partition, since each `h0` region is written by an independent job.

## Tests
- `tests/test_hex_checks.py` — passes on all-UBIGINT; raises on a signed-BIGINT parent; `h0` exempt even when read back as BIGINT; value columns named like `height`/`h2o` are not matched.
- `tests/test_vector.py::test_repartition_orders_by_cng_fid_within_partition` — shuffled chunk input comes out physically sorted by `_cng_fid`.
- Synthetic repartition fixtures updated to use `UBIGINT` h-columns (matching real h3 output) so they satisfy the new invariant.

All vector + hex_checks tests pass; ruff (`E,F,W --ignore E501`) clean. Pre-existing raster/convert/k8s failures are environmental (`No module named 'osgeo'`), unchanged by this PR.

Closes #102
Closes #103

🤖 Generated with [Claude Code](https://claude.com/claude-code)