### PR TITLE
fix(#43): always synthesize _cng_fid on the parquet-input convert path

### DIFF
--- a/cng_datasets/vector/convert_to_parquet.py
+++ b/cng_datasets/vector/convert_to_parquet.py
@@ -542,8 +542,10 @@ def process_parquet_input(
         compression: Compression algorithm (ZSTD, GZIP, SNAPPY, NONE)
         compression_level: Compression level (1-22 for ZSTD)
         row_group_size: Number of rows per group
-        id_column: Specific ID column to use (auto-detected if not specified)
-        force_id: Create _cng_fid if no suitable ID column exists
+        id_column: Specific source column to use as the row id instead of
+            synthesizing _cng_fid (must exist in source)
+        force_id: Unused; kept for backwards compatibility (_cng_fid is always
+            created unless id_column is given or the source already has it)
         progress: Show progress during conversion
         target_crs: Target CRS for output (default: EPSG:4326)
         verbose: Print detailed debug information
@@ -578,7 +580,16 @@ def process_parquet_input(
 
         column_names = [col[0].lower() for col in columns]
 
-        # Determine ID column
+        # Determine ID handling. Always create a synthetic _cng_fid row
+        # identifier (issue #43) unless the user named an explicit id_column or
+        # the source already carries _cng_fid. Source columns such as 'fid',
+        # 'objectid', etc. are NOT trusted as row keys — they may be
+        # feature/geometry identifiers with multiple rows per value (e.g. the
+        # TPL Conservation Almanac's 'fid', one row per funding program per
+        # site), which makes the repartition join many-to-many. They are
+        # preserved unchanged alongside _cng_fid (matching check_id_column for
+        # the ST_Read path). force_id is accepted for backwards compatibility
+        # but always treated as True.
         needs_id = False
         id_col_name = None
 
@@ -587,20 +598,12 @@ def process_parquet_input(
                 id_col_name = id_column
             else:
                 raise ValueError(f"Specified ID column '{id_column}' not found in source data")
+        elif '_cng_fid' in column_names:
+            # Re-processing an already-converted dataset; don't duplicate it.
+            id_col_name = "_cng_fid"
         else:
-            # Look for common ID column names
-            common_ids = ['id', 'fid', 'objectid', 'gid', 'uid', '_cng_fid']
-            for id_name in common_ids:
-                if id_name in column_names:
-                    id_col_name = id_name
-                    break
-
-            if id_col_name is None:
-                if force_id:
-                    needs_id = True
-                    id_col_name = "_cng_fid"
-                else:
-                    raise ValueError("No ID column found and force_id=False")
+            needs_id = True
+            id_col_name = "_cng_fid"
 
         if needs_id:
             print(f"  Adding synthetic ID column: {id_col_name}")

--- a/tests/test_convert_to_parquet.py
+++ b/tests/test_convert_to_parquet.py
@@ -139,6 +139,104 @@ class TestConvertToParquet:
             if os.path.exists(output_path):
                 os.remove(output_path)
     
+    def test_parquet_input_with_nonunique_fid_gets_cng_fid(self):
+        """Parquet input whose 'fid' is a feature key (not row-unique) still gets
+        a row-unique _cng_fid (issue #43).
+
+        Mirrors the TPL Conservation Almanac case: multiple rows share one fid
+        (one row per funding program per site). The old parquet path picked 'fid'
+        as the id and never synthesized _cng_fid, making the repartition join
+        many-to-many. _cng_fid must be 1..N and additive (fid preserved).
+        """
+        with tempfile.TemporaryDirectory() as tmpdir:
+            source = os.path.join(tmpdir, "source.parquet")
+            output_path = os.path.join(tmpdir, "out.parquet")
+
+            con = duckdb.connect()
+            con.install_extension("spatial")
+            con.load_extension("spatial")
+            # 3 sites, fid repeated (2 + 2 + 1 = 5 rows): fid is NOT row-unique.
+            con.execute(f"""
+                COPY (
+                    SELECT * FROM (VALUES
+                        (42453, 'grant',   ST_Point(-122.4, 37.8)),
+                        (42453, 'bond',    ST_Point(-122.4, 37.8)),
+                        (42454, 'grant',   ST_Point(-122.5, 37.9)),
+                        (42454, 'private', ST_Point(-122.5, 37.9)),
+                        (42455, 'grant',   ST_Point(-122.6, 38.0))
+                    ) t(fid, program, geom)
+                ) TO '{source}' (FORMAT PARQUET)
+            """)
+            con.close()
+
+            convert_to_parquet(
+                source_url=source,
+                destination=output_path,
+                force_id=True,
+                progress=False,
+            )
+
+            con = duckdb.connect()
+            cols = con.execute(
+                f"DESCRIBE SELECT * FROM read_parquet('{output_path}')"
+            ).fetchdf()['column_name'].tolist()
+            assert 'fid' in cols, "Source fid must be preserved"
+            assert '_cng_fid' in cols, "_cng_fid must be synthesized even when fid exists"
+
+            count = con.execute(
+                f"SELECT COUNT(*) FROM read_parquet('{output_path}')"
+            ).fetchone()[0]
+            distinct = con.execute(
+                f"SELECT COUNT(DISTINCT _cng_fid) FROM read_parquet('{output_path}')"
+            ).fetchone()[0]
+            assert count == 5 and distinct == 5, (
+                f"_cng_fid must be row-unique: {distinct} distinct / {count} rows"
+            )
+            # fid stays non-unique (proves it was the wrong row key).
+            fid_distinct = con.execute(
+                f"SELECT COUNT(DISTINCT fid) FROM read_parquet('{output_path}')"
+            ).fetchone()[0]
+            assert fid_distinct == 3, "fid should remain a (non-unique) feature key"
+            con.close()
+
+    def test_parquet_input_preserves_existing_cng_fid(self):
+        """A parquet source that already carries _cng_fid is not re-numbered."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            source = os.path.join(tmpdir, "source.parquet")
+            output_path = os.path.join(tmpdir, "out.parquet")
+
+            con = duckdb.connect()
+            con.install_extension("spatial")
+            con.load_extension("spatial")
+            con.execute(f"""
+                COPY (
+                    SELECT * FROM (VALUES
+                        (100, ST_Point(-122.4, 37.8)),
+                        (200, ST_Point(-122.5, 37.9))
+                    ) t(_cng_fid, geom)
+                ) TO '{source}' (FORMAT PARQUET)
+            """)
+            con.close()
+
+            convert_to_parquet(
+                source_url=source,
+                destination=output_path,
+                force_id=True,
+                progress=False,
+            )
+
+            con = duckdb.connect()
+            ids = con.execute(
+                f"SELECT _cng_fid FROM read_parquet('{output_path}') ORDER BY _cng_fid"
+            ).fetchdf()['_cng_fid'].tolist()
+            cols = con.execute(
+                f"DESCRIBE SELECT * FROM read_parquet('{output_path}')"
+            ).fetchdf()['column_name'].tolist()
+            con.close()
+
+            assert ids == [100, 200], f"existing _cng_fid must be preserved, got {ids}"
+            assert cols.count('_cng_fid') == 1, "must not duplicate _cng_fid"
+
     def test_geoparquet_metadata_is_valid(self, sample_geojson):
         """Test that output has valid GeoParquet metadata."""
         with tempfile.NamedTemporaryFile(suffix='.parquet', delete=False) as f:


### PR DESCRIPTION
Second roadmap item from #114 — pairs with #103 (row-group pruning by `_cng_fid` assumes a reliably row-unique `_cng_fid` exists).

## The gap
#43 ("always create `_cng_fid`") was **already done for `ST_Read` sources** ([`check_id_column`](https://github.com/boettiger-lab/datasets/blob/main/cng_datasets/vector/convert_to_parquet.py#L379)), but the **parquet-input path** (`process_parquet_input`) still did the old thing: pick the first of `['id','fid','objectid','gid','uid','_cng_fid']` as the row key, and only synthesize `_cng_fid` when none were present.

That's exactly the trap #43 describes. A source `fid` can be a **feature/geometry** identifier with multiple rows per value — the TPL Conservation Almanac has one row per funding program per site, all sharing a `fid`. Using it as the repartition join key makes the join many-to-many and can misassign attributes to hex cells.

## The fix
`process_parquet_input` now mirrors `check_id_column`: **always create `_cng_fid`** unless

- the user named an explicit `id_column` (use it), or
- the source already carries `_cng_fid` (don't duplicate / re-number).

Source columns (`fid`, `objectid`, …) are preserved unchanged — `_cng_fid` is additive. `force_id` is kept for backwards compatibility but is always treated as `True` (matching the `ST_Read` path; docstring updated).

## Tests
- `test_parquet_input_with_nonunique_fid_gets_cng_fid` — a parquet source whose `fid` repeats (3 sites / 5 rows) gets a 1..N row-unique `_cng_fid`; `fid` is preserved and stays non-unique.
- `test_parquet_input_preserves_existing_cng_fid` — an existing `_cng_fid` is neither re-numbered nor duplicated.

`TestConvertToParquet` passes (5/5); ruff (`E,F,W --ignore E501`) clean. Pre-existing `TestReprojection`/`TestMultipointGeometry` errors are environmental (`No module named 'osgeo'`), untouched by this PR.

Closes #43

🤖 Generated with [Claude Code](https://claude.com/claude-code)