### PR TITLE
fix(#61): cast BLOB WKB geometry to GEOMETRY on the parquet-input convert path

### DIFF
--- a/cng_datasets/vector/convert_to_parquet.py
+++ b/cng_datasets/vector/convert_to_parquet.py
@@ -610,17 +610,37 @@ def process_parquet_input(
         else:
             print(f"  Using existing ID column: {id_col_name}")
 
-        # Build query to read and optionally add ID
+        # Detect a BLOB-typed WKB geometry column (e.g. MULTIPOINT) so we can
+        # cast it to GEOMETRY. Otherwise DuckDB writes it back as BLOB with no
+        # GeoParquet metadata and the downstream PMTiles step (ogr2ogr) sees raw
+        # binary and produces null geometries (issue #61). Mirrors the ST_Read
+        # path's get_geometry_column / ST_GeomFromWKB handling.
+        geom_blob_col = None
+        for col_name, col_type, *_ in columns:
+            if col_type.upper() == 'BLOB' and col_name.lower() in _GEOM_COLUMN_NAMES:
+                geom_blob_col = col_name
+                break
+
+        if geom_blob_col:
+            print(f"  Casting BLOB geometry column to GEOMETRY: {geom_blob_col}")
+            cols_expr = (
+                f'* EXCLUDE ("{geom_blob_col}"), '
+                f'ST_GeomFromWKB("{geom_blob_col}") AS "{geom_blob_col}"'
+            )
+        else:
+            cols_expr = "*"
+
+        # Build query to read, cast geometry, and optionally add ID
         if needs_id:
             query = f"""
             SELECT
                 ROW_NUMBER() OVER () AS {id_col_name},
-                *
+                {cols_expr}
             FROM read_parquet('{read_url}')
             """
         else:
             query = f"""
-            SELECT * FROM read_parquet('{read_url}')
+            SELECT {cols_expr} FROM read_parquet('{read_url}')
             """
 
         # Write with DuckDB

--- a/tests/test_convert_to_parquet.py
+++ b/tests/test_convert_to_parquet.py
@@ -1066,3 +1066,65 @@ class TestMultipointGeometry:
         finally:
             if os.path.exists(output_path):
                 os.remove(output_path)
+
+    def test_parquet_input_blob_geometry_cast_to_geometry(self):
+        """A parquet input whose geom is a BLOB-typed WKB column must come out as
+        GEOMETRY with GeoParquet metadata (issue #61).
+
+        The ST_Read path was fixed in #75, but the parquet-input path
+        (process_parquet_input) passed BLOB geometry through unchanged, so a
+        MULTIPOINT-derived parquet stayed BLOB and broke PMTiles. No ogr2ogr
+        needed — the BLOB-geom source is built directly with DuckDB.
+        """
+        with tempfile.TemporaryDirectory() as tmpdir:
+            source = os.path.join(tmpdir, "blob_geom.parquet")
+            output_path = os.path.join(tmpdir, "out.parquet")
+
+            con = duckdb.connect()
+            con.install_extension("spatial")
+            con.load_extension("spatial")
+            # ST_AsWKB yields a BLOB column — the exact shape ST_Read emits for
+            # MULTIPOINT sources before the cast.
+            con.execute(f"""
+                COPY (
+                    SELECT 'A' AS name,
+                           ST_AsWKB(ST_GeomFromText('MULTIPOINT((-122.4 37.8),(-122.5 37.9))')) AS geom
+                    UNION ALL
+                    SELECT 'B' AS name,
+                           ST_AsWKB(ST_GeomFromText('MULTIPOINT((-122.6 38.0),(-122.7 38.1))')) AS geom
+                ) TO '{source}' (FORMAT PARQUET)
+            """)
+            assert con.execute(
+                f"SELECT typeof(geom) FROM read_parquet('{source}') LIMIT 1"
+            ).fetchone()[0] == "BLOB", "fixture precondition: input geom must be BLOB"
+            con.close()
+
+            convert_to_parquet(
+                source_url=source,
+                destination=output_path,
+                force_id=True,
+                progress=False,
+            )
+
+            con = duckdb.connect()
+            con.install_extension("spatial")
+            con.load_extension("spatial")
+            schema = con.execute(
+                f"DESCRIBE SELECT * FROM read_parquet('{output_path}')"
+            ).fetchall()
+            geom_col_type = next((row[1] for row in schema if row[0] == "geom"), None)
+            assert geom_col_type is not None and geom_col_type.startswith("GEOMETRY"), (
+                f"Expected GEOMETRY column, got {geom_col_type!r}"
+            )
+            geom_types = {
+                row[0] for row in con.execute(
+                    f"SELECT DISTINCT ST_GeometryType(geom) FROM read_parquet('{output_path}')"
+                ).fetchall()
+            }
+            assert geom_types == {"MULTIPOINT"}, f"Unexpected geometry types: {geom_types}"
+            con.close()
+
+            # GeoParquet metadata (the 'geo' key) must be present.
+            import pyarrow.parquet as pq
+            metadata = pq.read_table(output_path).schema.metadata or {}
+            assert b"geo" in metadata, "Output must carry GeoParquet 'geo' metadata"


### PR DESCRIPTION
Next roadmap item from #114 (section B, contained convert-step metadata fix).

## The gap (same shape as #43)
#61 was **already fixed for the ST_Read path** in #75 — `get_geometry_column` detects a BLOB-typed geometry column (DuckDB's `ST_Read` returns BLOB for MULTIPOINT / M-Z variants) and `build_read_reproject_query` casts it via `ST_GeomFromWKB` so DuckDB writes GeoParquet column metadata. But the **parquet-input path** (`process_parquet_input`) passed the geometry column through unchanged.

So a parquet whose `geom` is a BLOB-typed WKB column stayed `BLOB` with no `geo` metadata, and the PMTiles step (ogr2ogr) saw raw binary → null geometries. Reproduced locally:

\`\`\`
INPUT geom type: BLOB
OUTPUT geom type: BLOB        # before fix
has 'geo' metadata key: False
\`\`\`

## The fix
`process_parquet_input` now detects a BLOB-typed column whose name is in `_GEOM_COLUMN_NAMES` and rewrites it as `ST_GeomFromWKB("col") AS "col"`, mirroring the ST_Read path. Properly-typed `GEOMETRY` inputs and non-geometry BLOBs are untouched.

Verified across three inputs:

| Input | Before | After |
|-------|--------|-------|
| BLOB MULTIPOINT | `BLOB`, no geo meta | `GEOMETRY('OGC:CRS84')`, MULTIPOINT, geo meta ✓ |
| BLOB POINT | `BLOB` | `GEOMETRY('OGC:CRS84')`, POINT, geo meta ✓ |
| native GEOMETRY | `GEOMETRY` | unchanged ✓ |

## Test
`test_parquet_input_blob_geometry_cast_to_geometry` builds the BLOB-geom source directly with DuckDB (**no ogr2ogr dependency**, so it runs in CI unlike the existing GDB-based MULTIPOINT test) and asserts the output is `GEOMETRY`, round-trips as MULTIPOINT, and carries the GeoParquet `geo` key.

`TestConvertToParquet` + new test pass (6/6); ruff (`E,F,W --ignore E501`) clean.

Closes #61

🤖 Generated with [Claude Code](https://claude.com/claude-code)