### PR TITLE
fix(#119): clear error for unsupported geometry encodings on the parquet-input path

### DIFF
--- a/cng_datasets/vector/convert_to_parquet.py
+++ b/cng_datasets/vector/convert_to_parquet.py
@@ -610,16 +610,43 @@ def process_parquet_input(
         else:
             print(f"  Using existing ID column: {id_col_name}")
 
-        # Detect a BLOB-typed WKB geometry column (e.g. MULTIPOINT) so we can
-        # cast it to GEOMETRY. Otherwise DuckDB writes it back as BLOB with no
-        # GeoParquet metadata and the downstream PMTiles step (ogr2ogr) sees raw
-        # binary and produces null geometries (issue #61). Mirrors the ST_Read
-        # path's get_geometry_column / ST_GeomFromWKB handling.
+        # Classify the geometry column. DuckDB ingests a native GEOMETRY column
+        # directly, and a BLOB-typed WKB column via ST_GeomFromWKB (e.g.
+        # MULTIPOINT — issue #61); without that cast DuckDB writes BLOB back with
+        # no GeoParquet metadata and the PMTiles step produces null geometries.
+        # Any OTHER encoding read_parquet exposes — notably geoarrow-native (a
+        # STRUCT column) or WKT (VARCHAR) — cannot be operated on by DuckDB and
+        # would otherwise pass through verbatim as a non-GEOMETRY column with no
+        # GeoParquet metadata, silently breaking every downstream consumer
+        # (issue #119). Detect that and fail with an actionable message.
+        has_geometry = any(ct.upper().startswith('GEOMETRY') for _, ct, *_ in columns)
         geom_blob_col = None
+        geom_unsupported = None  # (name, type) of a geom-named column we can't ingest
         for col_name, col_type, *_ in columns:
-            if col_type.upper() == 'BLOB' and col_name.lower() in _GEOM_COLUMN_NAMES:
+            if col_name.lower() not in _GEOM_COLUMN_NAMES:
+                continue
+            ct = col_type.upper()
+            if ct == 'BLOB':
                 geom_blob_col = col_name
-                break
+            elif not ct.startswith('GEOMETRY'):
+                geom_unsupported = (col_name, col_type)
+
+        # Only error when there is no usable geometry at all (no native GEOMETRY,
+        # no castable BLOB) but a geom-named column exists in an encoding we can't
+        # handle. This avoids false positives when a real GEOMETRY column
+        # coexists with, say, a numeric column named "shape".
+        if not has_geometry and geom_blob_col is None and geom_unsupported is not None:
+            bad_name, bad_type = geom_unsupported
+            raise ValueError(
+                f"Geometry column '{bad_name}' has type {bad_type}, which DuckDB "
+                f"cannot ingest directly (typically geoarrow-native or WKT "
+                f"encoding). DuckDB is the supported engine; re-encode the source "
+                f"as WKB GeoParquet first and re-run, e.g.:\n"
+                f"    ogr2ogr -f Parquet fixed.parquet '{source_url}'\n"
+                f"  or in Python:\n"
+                f"    geopandas.read_parquet('{source_url}')"
+                f".to_parquet('fixed.parquet', geometry_encoding='WKB')"
+            )
 
         if geom_blob_col:
             print(f"  Casting BLOB geometry column to GEOMETRY: {geom_blob_col}")

--- a/tests/test_convert_to_parquet.py
+++ b/tests/test_convert_to_parquet.py
@@ -1128,3 +1128,49 @@ class TestMultipointGeometry:
             import pyarrow.parquet as pq
             metadata = pq.read_table(output_path).schema.metadata or {}
             assert b"geo" in metadata, "Output must carry GeoParquet 'geo' metadata"
+
+    def test_geoarrow_native_input_raises_clear_error(self):
+        """A geoarrow-native-encoded parquet (geometry as STRUCT, not WKB) must
+        raise a clear, actionable error rather than silently passing the
+        non-GEOMETRY column through with no GeoParquet metadata (issue #119).
+        """
+        import geopandas as gpd
+        from shapely.geometry import Polygon
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            source = os.path.join(tmpdir, "geoarrow_native.parquet")
+            output_path = os.path.join(tmpdir, "out.parquet")
+
+            gdf = gpd.GeoDataFrame(
+                {"name": ["a", "b"]},
+                geometry=[
+                    Polygon([(-122.5, 37.7), (-122.4, 37.7), (-122.4, 37.8), (-122.5, 37.8)]),
+                    Polygon([(-121.5, 38.7), (-121.4, 38.7), (-121.4, 38.8), (-121.5, 38.8)]),
+                ],
+                crs="EPSG:4326",
+            )
+            gdf.to_parquet(source, geometry_encoding="geoarrow")
+
+            # Precondition: DuckDB sees the geometry as a STRUCT, not GEOMETRY/BLOB.
+            con = duckdb.connect()
+            con.install_extension("spatial")
+            con.load_extension("spatial")
+            geom_type = next(
+                row[1] for row in con.execute(
+                    f"DESCRIBE SELECT * FROM read_parquet('{source}')"
+                ).fetchall() if row[0] == "geometry"
+            )
+            con.close()
+            assert geom_type.upper().startswith("STRUCT"), (
+                f"fixture precondition: expected STRUCT geom, got {geom_type}"
+            )
+
+            with pytest.raises(ValueError, match="DuckDB cannot ingest directly"):
+                convert_to_parquet(
+                    source_url=source,
+                    destination=output_path,
+                    force_id=True,
+                    progress=False,
+                )
+            # Nothing should have been written.
+            assert not os.path.exists(output_path)


### PR DESCRIPTION
## Problem
`process_parquet_input` recognized only two geometry encodings: native `GEOMETRY`, and `BLOB`-WKB (cast via `ST_GeomFromWKB`, #61). Any other encoding `read_parquet` exposes — **geoarrow-native** (a `STRUCT(x,y)` column) or WKT (`VARCHAR`) — fell through and was copied verbatim. The job printed "✓ completed successfully" while emitting a non-`GEOMETRY` column with **no GeoParquet metadata**, silently breaking the MCP/PMTiles consumers. (Found while building MREs for #106 — see #119.)

## Fix
DuckDB stays the engine. When there is **no usable geometry** (no native `GEOMETRY`, no castable `BLOB`) but a geometry-named column exists in an encoding DuckDB can't operate on, raise a clear `ValueError` naming the detected type and showing how to re-encode to WKB GeoParquet:

```
Geometry column 'geometry' has type STRUCT(x DOUBLE, y DOUBLE), which DuckDB
cannot ingest directly (typically geoarrow-native or WKT encoding). ...
    ogr2ogr -f Parquet fixed.parquet 'in.parquet'
  or in Python:
    geopandas.read_parquet('in.parquet').to_parquet('fixed.parquet', geometry_encoding='WKB')
```

Auto-conversion is intentionally out of scope (per discussion: a clear, actionable error the user adopts manually). The check is gated on the *absence* of any usable geometry, so a real `GEOMETRY` column coexisting with, e.g., a numeric column named `shape` does **not** false-positive.

## Verified
| Input encoding | Before | After |
|---|---|---|
| geoarrow-native (`STRUCT`) | silent pass-through, no `geo` metadata | clear `ValueError` with remedy ✓ |
| WKB-encoded GeoParquet | `GEOMETRY` ✓ | `GEOMETRY` ✓ (unchanged) |
| BLOB-WKB | `GEOMETRY` via cast ✓ | unchanged ✓ |

New regression test `test_geoarrow_native_input_raises_clear_error`; `TestConvertToParquet` + BLOB-cast test still green (7/7); ruff clean.

Closes #119

🤖 Generated with [Claude Code](https://claude.com/claude-code)