### PR TITLE
fix(#107): graceful guardrail for oversized per-feature H3 cell arrays

### DIFF
--- a/cng_datasets/vector/h3_tiling.py
+++ b/cng_datasets/vector/h3_tiling.py
@@ -20,6 +20,16 @@ _H3_EDGE_KM = {
     12: 0.010830188, 13: 0.004092010, 14: 0.001546100, 15: 0.000584169,
 }
 
+# Pass 1 writes each feature's H3 cells as a single list value. DuckDB/Arrow
+# cannot hold one list value larger than 2^31-1 bytes — i.e. ~268M UBIGINT
+# cells — and the parquet page-size assertion (PrimitiveColumnWriter::NextPage)
+# can fire below that. We refuse a feature whose estimated cell count exceeds a
+# conservative fraction of that ceiling, raising a clear error instead of a C++
+# assertion (issue #107). The estimate (spheroid area / average hex area)
+# undercounts the true polyfill by ~1.3x, so the default leaves wide margin.
+# Override via the CNG_MAX_CELLS_PER_FEATURE environment variable.
+_DEFAULT_MAX_CELLS_PER_FEATURE = 134_000_000
+
 
 def _h3_edge_length_degrees(resolution: int) -> float:
     """Return the H3 edge length in degrees for a given resolution.
@@ -313,6 +323,9 @@ class H3VectorProcessor:
         self.id_column = id_column
         self.read_credentials = read_credentials
         self.write_credentials = write_credentials
+        self.max_cells_per_feature = int(
+            os.environ.get("CNG_MAX_CELLS_PER_FEATURE", _DEFAULT_MAX_CELLS_PER_FEATURE)
+        )
 
         self.con = setup_duckdb_connection()
         self._configure_credentials()
@@ -329,6 +342,47 @@ class H3VectorProcessor:
             if col.upper() in ['SHAPE', 'GEOMETRY', 'GEOM']:
                 return col
         raise ValueError(f"No geometry column found. Available columns: {columns}")
+
+    def _assert_no_oversized_feature(self, id_col: str, chunk_id: int) -> None:
+        """Fail fast if any feature in `chunk_table` would produce an H3 cell
+        array exceeding the single-array size limit (issue #107).
+
+        Estimates per-feature cell count as spheroid area / average hex area at
+        the target resolution and raises a clear RuntimeError naming the worst
+        offender (id, area, estimated cells) if it exceeds
+        ``self.max_cells_per_feature``. This converts an otherwise-fatal C++
+        page-size assertion in the Pass-1 COPY into an actionable error.
+        """
+        avg_hex_m2 = self.con.execute(
+            f"SELECT h3_get_hexagon_area_avg({self.h3_resolution}, 'm^2')"
+        ).fetchone()[0]
+
+        worst = self.con.execute(f"""
+            SELECT
+                "{id_col}" AS fid,
+                ST_Area_Spheroid(geom) AS area_m2,
+                ST_Area_Spheroid(geom) / {avg_hex_m2} AS est_cells
+            FROM chunk_table
+            WHERE ST_GeometryType(geom) NOT IN ('POINT', 'MULTIPOINT')
+            ORDER BY est_cells DESC
+            LIMIT 1
+        """).fetchone()
+
+        if worst is None or worst[2] is None:
+            return
+        fid, area_m2, est_cells = worst
+        if est_cells > self.max_cells_per_feature:
+            raise RuntimeError(
+                f"Chunk {chunk_id}: feature {id_col}={fid} is too large to hex at "
+                f"resolution {self.h3_resolution} — estimated {int(est_cells):,} H3 "
+                f"cells ({area_m2 / 1e6:,.0f} km²) would exceed the per-feature "
+                f"cell-array limit ({self.max_cells_per_feature:,}). A single "
+                f"feature's cells are written as one array value, which cannot "
+                f"exceed the ~268M-element (2GB) Arrow/parquet-page ceiling. "
+                f"Hex this feature at a coarser resolution (see #98 for adaptive "
+                f"variable-resolution polyfill), or raise CNG_MAX_CELLS_PER_FEATURE "
+                f"if your build tolerates a larger array."
+            )
 
     def process_chunk(
         self,
@@ -415,6 +469,14 @@ class H3VectorProcessor:
             SELECT "{id_col}", {geom_col} AS geom
             FROM {chunk_view_name}
         """)
+
+        # Guard against a single feature whose H3 cell array would exceed the
+        # 2GB / parquet-page limit (issue #107). Estimate per-feature cell count
+        # up front (spheroid area / average hex area) and fail with a clear,
+        # actionable error naming the feature, rather than letting the COPY below
+        # die on a C++ assertion. ST_Area_Spheroid needs no reprojection, so it
+        # is robust on the pathological/antimeridian polygons that trigger this.
+        self._assert_no_oversized_feature(id_col, chunk_id)
 
         # Generate H3 arrays WITHOUT unnesting
         h3_sql = geom_to_h3_cells(

--- a/tests/test_vector.py
+++ b/tests/test_vector.py
@@ -751,6 +751,64 @@ class TestVectorProcessing:
             processor.con.close()
 
 
+class TestOversizedFeatureGuard:
+    """Issue #107: a feature whose H3 cell array would exceed the 2GB/page limit
+    must fail with a clear, actionable error instead of a C++ assertion."""
+
+    def _make_source(self, tmpdir):
+        src = f"{tmpdir}/polys.parquet"
+        con = setup_duckdb_connection()
+        # Feature 1: ~2deg box (~67k cells at res 8); Feature 2: tiny box.
+        con.execute(f"""
+            COPY (
+                SELECT 1 AS _cng_fid, ST_GeomFromText('POLYGON((0 0,2 0,2 2,0 2,0 0))') AS geom
+                UNION ALL
+                SELECT 2 AS _cng_fid, ST_GeomFromText('POLYGON((10 10,10.01 10,10.01 10.01,10 10.01,10 10))') AS geom
+            ) TO '{src}' (FORMAT PARQUET)
+        """)
+        con.close()
+        return src
+
+    @pytest.mark.timeout(30)
+    def test_oversized_feature_raises_clear_error(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            src = self._make_source(tmpdir)
+            processor = H3VectorProcessor(
+                input_url=src, output_url=f"{tmpdir}/out",
+                h3_resolution=8, parent_resolutions=[0], chunk_size=500,
+            )
+            processor.max_cells_per_feature = 50_000  # below feature 1's ~67k estimate
+            with pytest.raises(RuntimeError, match=r"_cng_fid=1 is too large"):
+                processor._process_pass1(0)
+            processor.con.close()
+
+    @pytest.mark.timeout(30)
+    def test_normal_features_pass_under_default_threshold(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            src = self._make_source(tmpdir)
+            processor = H3VectorProcessor(
+                input_url=src, output_url=f"{tmpdir}/out",
+                h3_resolution=8, parent_resolutions=[0], chunk_size=500,
+            )
+            # Default threshold (~134M) is far above these features.
+            out = processor._process_pass1(0)
+            n = processor.con.execute(
+                f"SELECT COUNT(*) FROM read_parquet('{out}')"
+            ).fetchone()[0]
+            assert n == 2
+            processor.con.close()
+
+    def test_threshold_from_env(self, monkeypatch):
+        monkeypatch.setenv("CNG_MAX_CELLS_PER_FEATURE", "12345")
+        with tempfile.TemporaryDirectory() as tmpdir:
+            src = self._make_source(tmpdir)
+            processor = H3VectorProcessor(
+                input_url=src, output_url=f"{tmpdir}/out", h3_resolution=8,
+            )
+            assert processor.max_cells_per_feature == 12345
+            processor.con.close()
+
+
 class TestSwappedCoordinateDetection:
     """Test that swapped lat/lon coordinates are detected and raise an error."""
 


### PR DESCRIPTION
## Problem
Hex Pass 1 writes each feature's H3 cells as a **single list value**. A near-global feature (e.g. an IUCN marine range) at a fine resolution produces hundreds of millions of cells, exceeding the ~268M-element (2 GB) Arrow array / parquet page-size limit (`PrimitiveColumnWriter::NextPage`). DuckDB then dies on a **C++ assertion** that raising `--hex-memory` cannot fix — failure mode #1 in #107.

## Fix (DuckDB-native, no GDAL)
`H3VectorProcessor._assert_no_oversized_feature` estimates each feature's cell count up front and fails fast with a clear, actionable error **before** the COPY:

```
Chunk 0: feature _cng_fid=1 is too large to hex at resolution 8 — estimated
66,770 H3 cells (49,232 km²) would exceed the per-feature cell-array limit
(50,000). A single feature's cells are written as one array value, which
cannot exceed the ~268M-element (2GB) Arrow/parquet-page ceiling. Hex this
feature at a coarser resolution (see #98 ...), or raise CNG_MAX_CELLS_PER_FEATURE ...
```

- **Estimator:** `ST_Area_Spheroid(geom) / h3_get_hexagon_area_avg(res)` — needs **no reprojection**, so it's robust on the pathological/antimeridian polygons that trigger this (verified: tracks actual polyfill within a stable ~1.3× factor across 1–8° boxes).
- **Threshold:** default `134_000_000` estimated cells (conservative vs the hard ceiling, since the estimate undercounts by ~1.3×), overridable via `CNG_MAX_CELLS_PER_FEATURE`. Points/multipoints exempt.
- Automatic per-feature **resolution back-off is intentionally deferred to #98** (adaptive variable-resolution polyfill); this PR is the guardrail only.

### On #107's second failure mode
#107 also lists a GDAL `ogr2ogr -f Parquet` 2 GB write failure. That path **does not exist** in our pipeline — per the DuckDB-as-standard decision we are not adding a GDAL write path — so that sub-case is moot here. Closing #107 on the guardrail; reopen if a GDAL write path is ever introduced.

## Tests
`TestOversizedFeatureGuard`: oversized feature raises (clear message, low threshold), normal features pass under the default, and `CNG_MAX_CELLS_PER_FEATURE` is honored. Full `tests/test_vector.py` green (44 passed); ruff clean. (Verified at low RAM — no multi-GB arrays materialized.)

Closes #107

🤖 Generated with [Claude Code](https://claude.com/claude-code)