### PR TITLE
feat(#98): adaptive variable-resolution H3 polyfill via --resolution-by-area

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+- `--resolution-by-area` for variable-resolution (size-stratified) H3 hex tiling: each feature is hexed at the native resolution its planar `ST_Area` maps to, so very large polygons use a coarse resolution while small ones keep fine edges — avoiding the Pass-2 OOM / 2 GB parquet-page limit without dropping the whole dataset to a coarse resolution. Output carries a uniform union schema (one column per resolution, finer columns null in coarser tiers) plus a `native_res` column, preserving flat equality joins. The #107 oversized-feature guardrail now estimates each feature's cells at its own native resolution, so large features back off automatically (#98)
+
 ## [0.2.0] - 2026-06-13
 
 ### Added

--- a/cng_datasets/cli.py
+++ b/cng_datasets/cli.py
@@ -21,7 +21,15 @@ def main():
     vector_parser = subparsers.add_parser("vector", help="Process vector datasets")
     vector_parser.add_argument("--input", required=True, help="Input file URL")
     vector_parser.add_argument("--output", required=True, help="Output directory URL")
-    vector_parser.add_argument("--resolution", type=int, default=10, help="H3 resolution")
+    vector_res_group = vector_parser.add_mutually_exclusive_group()
+    vector_res_group.add_argument("--resolution", type=int, default=10, help="H3 resolution")
+    vector_res_group.add_argument(
+        "--resolution-by-area", type=str, default=None,
+        help="Variable resolution by polygon area (issue #98). Comma-separated "
+             "'threshold:resolution' bins (planar deg2) plus a trailing catch-all "
+             "resolution, e.g. '12:8,600:6,5' (area<=12 -> res 8, <=600 -> res 6, "
+             "else res 5). Output carries a union schema + native_res column. "
+             "Include 0 in --parent-resolutions so the h0 partition column exists.")
     vector_parser.add_argument("--chunk-size", type=int, default=500, help="Number of rows to process in pass 1 (geometry to H3 arrays)")
     vector_parser.add_argument("--intermediate-chunk-size", type=int, default=10, help="Number of rows to process in pass 2 (unnesting arrays) - reduce if hitting OOM")
     vector_parser.add_argument("--chunk-id", type=int, help="Process specific chunk")
@@ -100,6 +108,11 @@ def main():
     workflow_parser.add_argument("--output-dir", default="k8s", help="Output directory for YAML files")
     workflow_parser.add_argument("--namespace", default="biodiversity", help="Kubernetes namespace (default: biodiversity)")
     workflow_parser.add_argument("--h3-resolution", type=int, default=None, help="Target H3 resolution (default: auto — 10 for polygons/points, 8 for lines)")
+    workflow_parser.add_argument(
+        "--resolution-by-area", type=str, default=None,
+        help="Variable resolution by polygon area (issue #98), e.g. '12:8,600:6,5'. "
+             "Mutually exclusive with --h3-resolution; emits the same flag into the "
+             "hex job. Include 0 in --parent-resolutions for the h0 partition column.")
     workflow_parser.add_argument("--parent-resolutions", type=str, default="9,8,0", help="Comma-separated parent H3 resolutions (default: '9,8,0')")
     workflow_parser.add_argument("--id-column", help="ID column name (auto-detected if not specified)")
     workflow_parser.add_argument("--layer", help="Layer name for multi-layer datasets (e.g., GDB files)")
@@ -209,8 +222,13 @@ def main():
 def _dispatch(args):
     if args.command == "vector":
         from .vector import process_vector_chunks
+        from .vector.h3_tiling import parse_resolution_by_area
         # Parse parent resolutions from comma-separated string
         parent_res = [int(x.strip()) for x in args.parent_resolutions.split(',') if x.strip()]
+        resolution_by_area = (
+            parse_resolution_by_area(args.resolution_by_area)
+            if args.resolution_by_area else None
+        )
         process_vector_chunks(
             input_url=args.input,
             output_url=args.output,
@@ -220,6 +238,7 @@ def _dispatch(args):
             chunk_size=args.chunk_size,
             intermediate_chunk_size=args.intermediate_chunk_size,
             id_column=args.id_column,
+            resolution_by_area=resolution_by_area,
         )
 
     elif args.command == "raster":
@@ -325,8 +344,14 @@ def _dispatch(args):
 
     elif args.command == "workflow":
         from .k8s import generate_dataset_workflow
+        from .vector.h3_tiling import parse_resolution_by_area
         # Parse parent resolutions from comma-separated string
         parent_res = [int(x.strip()) for x in args.parent_resolutions.split(',') if x.strip()]
+        if args.resolution_by_area and args.h3_resolution is not None:
+            raise ValueError("--resolution-by-area and --h3-resolution are mutually exclusive")
+        # Validate the spec early so workflow generation fails fast on a bad bin.
+        if args.resolution_by_area:
+            parse_resolution_by_area(args.resolution_by_area)
         generate_dataset_workflow(
             dataset_name=args.dataset,
             source_urls=args.source_urls,
@@ -334,6 +359,7 @@ def _dispatch(args):
             output_dir=args.output_dir,
             namespace=args.namespace,
             h3_resolution=args.h3_resolution,
+            resolution_by_area=args.resolution_by_area,
             parent_resolutions=parent_res,
             id_column=args.id_column,
             layer=args.layer,

--- a/cng_datasets/k8s/workflows.py
+++ b/cng_datasets/k8s/workflows.py
@@ -449,6 +449,7 @@ def generate_dataset_workflow(
     image: str = "ghcr.io/boettiger-lab/datasets:latest",
     git_repo: str = "https://github.com/boettiger-lab/datasets.git",
     h3_resolution: Optional[int] = None,
+    resolution_by_area: Optional[str] = None,
     parent_resolutions: Optional[List[int]] = None,
     id_column: Optional[str] = None,
     layer: Optional[str] = None,
@@ -534,8 +535,17 @@ def generate_dataset_workflow(
     if isinstance(source_urls, str):
         source_urls = [source_urls]
 
+    # Variable-resolution mode (issue #98): the hex job receives the
+    # --resolution-by-area spec instead of a single --h3-resolution. Derive the
+    # finest bin resolution from the spec for messaging / column naming, and skip
+    # geometry-type auto-detection (which only picks a single target resolution).
+    if resolution_by_area is not None:
+        from ..vector.h3_tiling import parse_resolution_by_area
+        bins = parse_resolution_by_area(resolution_by_area)
+        h3_resolution = max(res for _, res in bins)
+        print(f"  Variable resolution by area: {resolution_by_area} (finest res {h3_resolution})")
     # Auto-detect geometry type and set H3 resolution default if not specified
-    if h3_resolution is None:
+    elif h3_resolution is None:
         geom_type = _detect_geometry_type(source_urls, layer=layer)
         h3_resolution = _DEFAULT_H3_RESOLUTION.get(geom_type, 10)
         print(f"  Detected geometry type: {geom_type} — using H3 resolution {h3_resolution}")
@@ -580,7 +590,7 @@ def generate_dataset_workflow(
     print(f"  Parent resolutions: {parent_resolutions}")
 
     # Generate hex tiling job
-    _generate_hex_job(manager, k8s_name, bucket, output_path, git_repo, chunk_size, completions, parallelism, h3_resolution, parent_resolutions, id_column, hex_memory, intermediate_chunk_size, s3_dataset=dataset_name, hex_storage=hex_storage, config=config)
+    _generate_hex_job(manager, k8s_name, bucket, output_path, git_repo, chunk_size, completions, parallelism, h3_resolution, parent_resolutions, id_column, hex_memory, intermediate_chunk_size, s3_dataset=dataset_name, hex_storage=hex_storage, config=config, resolution_by_area=resolution_by_area)
 
     # Generate repartition job
     _generate_repartition_job(manager, k8s_name, bucket, output_path, git_repo, s3_dataset=dataset_name, repartition_storage=repartition_storage, repartition_memory=repartition_memory, config=config)
@@ -592,9 +602,12 @@ def generate_dataset_workflow(
     parent_res_str = ','.join(map(str, parent_resolutions))
     # Format source URLs for command recreation
     source_urls_str = ' '.join([f'--source-url {url}' for url in source_urls])
+    res_flag = (f"--resolution-by-area \"{resolution_by_area}\""
+                if resolution_by_area is not None
+                else f"--h3-resolution {h3_resolution}")
     gen_command = (f"cng-datasets workflow --dataset {dataset_name} "
                    f"{source_urls_str} --bucket {bucket} "
-                   f"--h3-resolution {h3_resolution} --parent-resolutions \"{parent_res_str}\"")
+                   f"{res_flag} --parent-resolutions \"{parent_res_str}\"")
 
     # Generate ConfigMap YAML from job files
     _generate_configmap(k8s_name, namespace, output_path, gen_command)
@@ -1331,7 +1344,7 @@ rm /tmp/$DATASET.geojsonl /tmp/$DATASET.pmtiles
     manager.save_job_yaml(job_spec, str(output_path / f"{dataset_name}-pmtiles.yaml"))
 
 
-def _generate_hex_job(manager, dataset_name, bucket, output_path, git_repo, chunk_size, completions, parallelism, h3_resolution, parent_resolutions, id_column=None, hex_memory="8Gi", intermediate_chunk_size=10, s3_dataset=None, hex_storage="10Gi", config: ClusterConfig = None):
+def _generate_hex_job(manager, dataset_name, bucket, output_path, git_repo, chunk_size, completions, parallelism, h3_resolution, parent_resolutions, id_column=None, hex_memory="8Gi", intermediate_chunk_size=10, s3_dataset=None, hex_storage="10Gi", config: ClusterConfig = None, resolution_by_area=None):
     """Generate H3 hex tiling job.
 
     Args:
@@ -1356,10 +1369,16 @@ def _generate_hex_job(manager, dataset_name, bucket, output_path, git_repo, chun
     # Format parent resolutions as comma-separated string
     parent_res_str = ','.join(map(str, parent_resolutions))
 
+    # Variable-resolution mode (issue #98) passes the per-area spec; otherwise a
+    # single target resolution. The spec needs quoting (it contains commas/colons).
+    res_flag = (f'--resolution-by-area "{resolution_by_area}"'
+                if resolution_by_area is not None
+                else f"--resolution {h3_resolution}")
+
     # Build command with optional id-column parameter
     cmd_parts = [
         "set -e",
-        f"cng-datasets vector --input s3://{bucket}/{s3_dataset}.parquet --output s3://{bucket}/{s3_dataset}/chunks --chunk-id ${{JOB_COMPLETION_INDEX}} --chunk-size {chunk_size} --intermediate-chunk-size {intermediate_chunk_size} --resolution {h3_resolution} --parent-resolutions {parent_res_str}"
+        f"cng-datasets vector --input s3://{bucket}/{s3_dataset}.parquet --output s3://{bucket}/{s3_dataset}/chunks --chunk-id ${{JOB_COMPLETION_INDEX}} --chunk-size {chunk_size} --intermediate-chunk-size {intermediate_chunk_size} {res_flag} --parent-resolutions {parent_res_str}"
     ]
     if id_column:
         cmd_parts[-1] += f" --id-column {id_column}"

--- a/cng_datasets/vector/h3_tiling.py
+++ b/cng_datasets/vector/h3_tiling.py
@@ -31,6 +31,108 @@ _H3_EDGE_KM = {
 _DEFAULT_MAX_CELLS_PER_FEATURE = 134_000_000
 
 
+def parse_resolution_by_area(spec: str) -> List[Tuple[Optional[float], int]]:
+    """Parse a ``--resolution-by-area`` spec into sorted (threshold, resolution) bins.
+
+    The spec stratifies polygons by their planar ``ST_Area`` (deg²; ~12,000 km²
+    per deg² at the equator) so very large features are hexed at a coarser native
+    resolution — avoiding the Pass-2 OOM / 2 GB parquet-page limit that uniform
+    fine resolution hits (issue #98). This is the proven "Plan A" used to build the
+    published ``iucn-ranges-2025/hex`` product.
+
+    Format: comma-separated ``threshold:resolution`` pairs plus a single trailing
+    bare ``resolution`` that is the catch-all for features larger than every
+    threshold. Example ``"12:8,600:6,5"`` means::
+
+        area <= 12   -> res 8
+        area <= 600  -> res 6
+        otherwise    -> res 5   (the catch-all)
+
+    Args:
+        spec: The raw ``--resolution-by-area`` string.
+
+    Returns:
+        Bins as ``(threshold, resolution)`` tuples sorted ascending by threshold,
+        terminated by exactly one catch-all ``(None, resolution)``.
+
+    Raises:
+        ValueError: malformed token, resolution out of [0, 15], no catch-all, or
+            more than one catch-all.
+    """
+    tokens = [t.strip() for t in spec.split(',') if t.strip()]
+    if not tokens:
+        raise ValueError(
+            "Empty --resolution-by-area spec. Expected e.g. '12:8,600:6,5' "
+            "(threshold:resolution pairs plus a trailing catch-all resolution)."
+        )
+
+    bins: List[Tuple[float, int]] = []
+    catchall: Optional[int] = None
+    for tok in tokens:
+        if ':' in tok:
+            thresh_str, res_str = tok.split(':', 1)
+            try:
+                threshold = float(thresh_str)
+                res = int(res_str)
+            except ValueError:
+                raise ValueError(
+                    f"Invalid --resolution-by-area bin '{tok}'. Expected "
+                    f"'threshold:resolution' with numeric values."
+                )
+            bins.append((threshold, res))
+        else:
+            if catchall is not None:
+                raise ValueError(
+                    f"--resolution-by-area has more than one catch-all resolution "
+                    f"(bare integer without a threshold). Found '{tok}' after a "
+                    f"catch-all was already set; only the final entry may be bare."
+                )
+            try:
+                catchall = int(tok)
+            except ValueError:
+                raise ValueError(
+                    f"Invalid --resolution-by-area catch-all '{tok}'. Expected a "
+                    f"bare integer resolution (the final entry)."
+                )
+
+    if catchall is None:
+        raise ValueError(
+            "--resolution-by-area requires a trailing catch-all resolution (a bare "
+            "integer with no threshold) for features larger than every threshold, "
+            "e.g. the '5' in '12:8,600:6,5'."
+        )
+
+    for _, res in bins:
+        if not 0 <= res <= 15:
+            raise ValueError(f"H3 resolution {res} out of range [0, 15] in --resolution-by-area.")
+    if not 0 <= catchall <= 15:
+        raise ValueError(f"H3 catch-all resolution {catchall} out of range [0, 15].")
+
+    bins.sort(key=lambda b: b[0])
+    for (t_prev, _), (t_cur, _) in zip(bins, bins[1:]):
+        if t_cur == t_prev:
+            raise ValueError(
+                f"--resolution-by-area has a duplicate threshold {t_cur}; the later "
+                f"bin would be unreachable. Use distinct, increasing thresholds."
+            )
+    return [(t, r) for t, r in bins] + [(None, catchall)]
+
+
+def _native_res_case_sql(bins: List[Tuple[Optional[float], int]], geom_expr: str) -> str:
+    """Build a SQL CASE expression mapping a geometry's planar area to its native
+    H3 resolution, given parsed ``--resolution-by-area`` bins.
+
+    The catch-all (``threshold is None``) becomes the ELSE branch.
+    """
+    whens = [
+        f"WHEN ST_Area({geom_expr}) <= {threshold} THEN {res}"
+        for threshold, res in bins
+        if threshold is not None
+    ]
+    catchall = next(res for threshold, res in bins if threshold is None)
+    return "CASE " + " ".join(whens) + f" ELSE {catchall} END"
+
+
 def _h3_edge_length_degrees(resolution: int) -> float:
     """Return the H3 edge length in degrees for a given resolution.
 
@@ -39,6 +141,20 @@ def _h3_edge_length_degrees(resolution: int) -> float:
     for a spatial index.
     """
     return _H3_EDGE_KM[resolution] / 111.32
+
+
+def _buffer_case_sql(native_res_col: str) -> str:
+    """Build a SQL CASE mapping a per-row native H3 resolution column to the line
+    buffer width in degrees (H3 edge length at that resolution).
+
+    Used only on the variable-resolution path (issue #98), where the buffer for a
+    line feature must track that feature's native_res rather than a fixed zoom.
+    """
+    whens = " ".join(
+        f"WHEN {res} THEN {_h3_edge_length_degrees(res)}" for res in sorted(_H3_EDGE_KM)
+    )
+    # Fall back to the finest resolution's edge length if native_res is unexpected.
+    return f"CASE {native_res_col} {whens} ELSE {_h3_edge_length_degrees(max(_H3_EDGE_KM))} END"
 
 
 def identify_id_column(
@@ -125,6 +241,7 @@ def geom_to_h3_cells(
     zoom: int = 10,
     keep_cols: Optional[List[str]] = None,
     geom_col: str = "geom",
+    resolution_by_area: Optional[List[Tuple[Optional[float], int]]] = None,
 ) -> str:
     """
     Convert geometries to H3 cells at specified resolution.
@@ -132,9 +249,14 @@ def geom_to_h3_cells(
     Args:
         con: DuckDB connection
         table_name: Name of the table or view with geometry column
-        zoom: H3 resolution level (0-15)
+        zoom: H3 resolution level (0-15). Used when resolution_by_area is None.
         keep_cols: List of columns to keep from input. If None, keeps all except geom.
         geom_col: Name of the geometry column
+        resolution_by_area: Optional parsed bins from parse_resolution_by_area. When
+            provided, each feature is hexed at the native resolution its planar
+            ST_Area maps to (issue #98), and a per-feature ``native_res`` column is
+            emitted alongside ``h3id``. Points/lines have ~0 planar area and so fall
+            in the finest (first) bin. When None, every feature is hexed at ``zoom``.
 
     Returns:
         SQL query string that generates H3 cells
@@ -179,6 +301,61 @@ def geom_to_h3_cells(
             f"Buffering by {buffer_deg:.6f} deg (~H3 edge length at res {zoom}) "
             f"before H3 polyfill to ensure continuous cell coverage."
         )
+
+    # Variable-resolution (issue #98): when resolution_by_area is provided, each
+    # feature is hexed at the native resolution its planar ST_Area maps to, a
+    # per-feature `native_res` column is emitted, and the H3 functions take that
+    # column (not a literal zoom) as the resolution argument — DuckDB's H3
+    # bindings accept a per-row resolution expression. The buffer width for line
+    # geometries likewise tracks each feature's native_res. Otherwise the
+    # original single-`zoom` path below is used unchanged.
+    if resolution_by_area is not None:
+        native_res_case = _native_res_case_sql(resolution_by_area, geom_col)
+        buffer_case = _buffer_case_sql("native_res")
+        return f'''
+        WITH tbase AS (
+            SELECT {col_list},
+                   {geom_col} AS _geom_orig,
+                   {native_res_case} AS native_res
+            FROM {table_name}
+        ),
+        t0 AS (
+            SELECT {col_list}, native_res,
+                   CASE
+                       WHEN ST_GeometryType(_geom_orig) IN ('LINESTRING', 'MULTILINESTRING')
+                       THEN ST_Multi(ST_Buffer(ST_Force2D(_geom_orig), {buffer_case}))
+                       WHEN ST_GeometryType(_geom_orig) = 'POLYGON'
+                       THEN ST_Multi(_geom_orig)
+                       ELSE _geom_orig
+                   END AS geom
+            FROM tbase
+        ),
+        t1 AS (
+            SELECT {col_list}, native_res,
+                   UNNEST(ST_Dump(geom)).geom AS geom
+            FROM t0
+        ),
+        t2 AS (
+            SELECT {col_list}, native_res, geom,
+                   CASE
+                       WHEN ST_GeometryType(geom) = 'POINT'
+                       THEN [h3_latlng_to_cell(ST_Y(geom), ST_X(geom), native_res)]
+                       ELSE h3_polygon_wkt_to_cells(ST_AsText(ST_Force2D(geom)), native_res)
+                   END AS h3id
+            FROM t1
+        )
+        SELECT {col_list}, native_res,
+               CASE
+                   WHEN h3id IS NOT NULL AND len(h3id) > 0 THEN h3id
+                   WHEN ST_YMin(geom) >= -90 AND ST_YMax(geom) <= 90
+                   THEN [h3_latlng_to_cell(
+                            ST_Y(ST_PointOnSurface(geom)),
+                            ST_X(ST_PointOnSurface(geom)),
+                            native_res)]
+                   ELSE h3id
+               END AS h3id
+        FROM t2
+        '''
 
     # Convert to multi-polygons and unnest, then generate H3 cells
     # The geometry is already GEOMETRY type in DuckDB spatial extension
@@ -297,6 +474,7 @@ class H3VectorProcessor:
         chunk_size: int = 500,
         intermediate_chunk_size: int = 10,
         id_column: Optional[str] = None,
+        resolution_by_area: Optional[List[Tuple[Optional[float], int]]] = None,
         read_credentials: Optional[Dict[str, str]] = None,
         write_credentials: Optional[Dict[str, str]] = None,
     ):
@@ -306,18 +484,41 @@ class H3VectorProcessor:
         Args:
             input_url: S3 URL or local path to input parquet/geoparquet file
             output_url: S3 URL or local path to output directory
-            h3_resolution: Target H3 resolution for tiling
+            h3_resolution: Target H3 resolution for tiling. Ignored when
+                resolution_by_area is set (the finest bin resolution is used).
             parent_resolutions: List of parent resolutions to include (e.g., [9, 8, 0])
             chunk_size: Number of rows to process in pass 1 (geometry to H3 arrays)
             intermediate_chunk_size: Number of rows to process in pass 2 (unnesting arrays)
             id_column: Name of ID column to use (auto-detected if not specified)
+            resolution_by_area: Optional parsed bins from parse_resolution_by_area
+                (issue #98). When set, each feature is hexed at the native resolution
+                its planar ST_Area maps to, and the output carries a union schema
+                (one column per resolution in the bins + parent_resolutions, finer
+                columns NULL in coarser tiers) plus a native_res column.
             read_credentials: Dict with AWS credentials for reading (key, secret, region, endpoint)
             write_credentials: Dict with AWS credentials for writing (key, secret, region, endpoint)
         """
         self.input_url = input_url
         self.output_url = output_url
-        self.h3_resolution = h3_resolution
+        self.resolution_by_area = resolution_by_area
+        # In variable-resolution mode the finest bin resolution stands in for
+        # h3_resolution wherever a single "target" resolution is needed (output
+        # column naming for the native cell, empty-polyfill latitude checks).
+        if resolution_by_area is not None:
+            self.h3_resolution = max(res for _, res in resolution_by_area)
+        else:
+            self.h3_resolution = h3_resolution
         self.parent_resolutions = parent_resolutions or [9, 8, 0]
+        if resolution_by_area is not None:
+            # The output must carry an h0 column: it is the hive partition key for
+            # the repartition step. Fail fast and clearly rather than letting
+            # repartition_by_h0 die on a missing-column binder error downstream.
+            res_set = {res for _, res in resolution_by_area} | set(self.parent_resolutions)
+            if 0 not in res_set:
+                raise ValueError(
+                    "--resolution-by-area output needs an h0 partition column; "
+                    "include 0 in --parent-resolutions (e.g. '7,6,5,4,0')."
+                )
         self.chunk_size = chunk_size
         self.intermediate_chunk_size = intermediate_chunk_size
         self.id_column = id_column
@@ -352,16 +553,32 @@ class H3VectorProcessor:
         offender (id, area, estimated cells) if it exceeds
         ``self.max_cells_per_feature``. This converts an otherwise-fatal C++
         page-size assertion in the Pass-1 COPY into an actionable error.
+
+        In variable-resolution mode (issue #98) the estimate uses each feature's
+        own native resolution — large features map to a coarser resolution and far
+        fewer cells, the per-feature back-off that complements this guardrail — and
+        the reported resolution is the worst offender's native res.
         """
-        avg_hex_m2 = self.con.execute(
-            f"SELECT h3_get_hexagon_area_avg({self.h3_resolution}, 'm^2')"
-        ).fetchone()[0]
+        if self.resolution_by_area is not None:
+            native_res_case = _native_res_case_sql(self.resolution_by_area, "geom")
+            est_cells_expr = (
+                f"ST_Area_Spheroid(geom) / "
+                f"h3_get_hexagon_area_avg({native_res_case}, 'm^2')"
+            )
+            res_select = f"{native_res_case} AS native_res"
+        else:
+            avg_hex_m2 = self.con.execute(
+                f"SELECT h3_get_hexagon_area_avg({self.h3_resolution}, 'm^2')"
+            ).fetchone()[0]
+            est_cells_expr = f"ST_Area_Spheroid(geom) / {avg_hex_m2}"
+            res_select = f"{self.h3_resolution} AS native_res"
 
         worst = self.con.execute(f"""
             SELECT
                 "{id_col}" AS fid,
                 ST_Area_Spheroid(geom) AS area_m2,
-                ST_Area_Spheroid(geom) / {avg_hex_m2} AS est_cells
+                {est_cells_expr} AS est_cells,
+                {res_select}
             FROM chunk_table
             WHERE ST_GeometryType(geom) NOT IN ('POINT', 'MULTIPOINT')
             ORDER BY est_cells DESC
@@ -370,11 +587,11 @@ class H3VectorProcessor:
 
         if worst is None or worst[2] is None:
             return
-        fid, area_m2, est_cells = worst
+        fid, area_m2, est_cells, native_res = worst
         if est_cells > self.max_cells_per_feature:
             raise RuntimeError(
                 f"Chunk {chunk_id}: feature {id_col}={fid} is too large to hex at "
-                f"resolution {self.h3_resolution} — estimated {int(est_cells):,} H3 "
+                f"resolution {native_res} — estimated {int(est_cells):,} H3 "
                 f"cells ({area_m2 / 1e6:,.0f} km²) would exceed the per-feature "
                 f"cell-array limit ({self.max_cells_per_feature:,}). A single "
                 f"feature's cells are written as one array value, which cannot "
@@ -483,7 +700,8 @@ class H3VectorProcessor:
             self.con,
             'chunk_table',
             zoom=self.h3_resolution,
-            keep_cols=[id_col]
+            keep_cols=[id_col],
+            resolution_by_area=self.resolution_by_area,
         )
 
         # Write arrays to intermediate file (NO UNNEST!)
@@ -528,9 +746,14 @@ class H3VectorProcessor:
                 f"Check input geometry coordinate order."
             )
         if small > 0:
+            res_desc = (
+                "their per-feature native resolution"
+                if self.resolution_by_area is not None
+                else f"resolution {self.h3_resolution}"
+            )
             print(
                 f"  Warning: {small} polygon feature(s) in chunk {chunk_id} produced 0 H3 cells "
-                f"at resolution {self.h3_resolution} even after the representative-point "
+                f"at {res_desc} even after the representative-point "
                 f"fallback — likely degenerate geometry. These features are dropped."
             )
 
@@ -559,15 +782,45 @@ class H3VectorProcessor:
         result = self.con.execute(f"SELECT * FROM read_parquet('{intermediate_file}') LIMIT 0").description
         id_col = result[0][0]  # First column is the ID
 
-        # Build parent resolution columns
-        h3_col = f"h{self.h3_resolution}"
-        parent_cols = []
-        for parent_res in sorted(self.parent_resolutions):
-            if parent_res < self.h3_resolution:
-                col_name = f"h{parent_res}"
-                parent_cols.append(f"h3_cell_to_parent({h3_col}, {parent_res}) AS {col_name}")
+        # Build the per-batch SELECT that unnests each feature's H3 cell array.
+        #
+        # Variable-resolution mode (issue #98): every chunk emits the same union
+        # schema — one h{r} column per resolution in {native resolutions} ∪
+        # {parent_resolutions} — so the schema is uniform across chunks and the
+        # repartition step is unaffected. For a row whose feature was hexed at
+        # native_res, each column h{r} is the cell's ancestor at r when r <=
+        # native_res (r == native_res returns the cell itself) and NULL otherwise.
+        # A per-row native_res column lets consumers filter to a tier. The common
+        # floor (coarsest native resolution) is non-null in every row, preserving
+        # flat equality joins.
+        if self.resolution_by_area is not None:
+            native_resolutions = {res for _, res in self.resolution_by_area}
+            finest_native = max(native_resolutions)
+            # Union of native + parent resolutions, but never finer than the
+            # finest native resolution: a parent res > finest_native could never
+            # be a rollup of any cell, so it would be an all-NULL column for every
+            # row (the fixed-resolution path likewise only emits parents < target).
+            col_resolutions = sorted(
+                {r for r in native_resolutions | set(self.parent_resolutions)
+                 if r <= finest_native},
+                reverse=True,
+            )
+            union_cols = [
+                f"CASE WHEN {r} <= native_res THEN h3_cell_to_parent(cell, {r}) "
+                f"ELSE CAST(NULL AS UBIGINT) END AS h{r}"
+                for r in col_resolutions
+            ]
+            union_cols_str = ', '.join(union_cols)
+        else:
+            # Build parent resolution columns
+            h3_col = f"h{self.h3_resolution}"
+            parent_cols = []
+            for parent_res in sorted(self.parent_resolutions):
+                if parent_res < self.h3_resolution:
+                    col_name = f"h{parent_res}"
+                    parent_cols.append(f"h3_cell_to_parent({h3_col}, {parent_res}) AS {col_name}")
 
-        parent_cols_str = ', ' + ', '.join(parent_cols) if parent_cols else ''
+            parent_cols_str = ', ' + ', '.join(parent_cols) if parent_cols else ''
 
         # Use local /tmp for fast batch processing, then copy to final destination
         local_output = f"/tmp/h3_output_{chunk_id:06d}.parquet"
@@ -579,14 +832,28 @@ class H3VectorProcessor:
             # Read small batch and unnest
             # IMPORTANT: Use subquery to apply LIMIT/OFFSET to input rows BEFORE unnest
             # Otherwise DuckDB applies LIMIT/OFFSET to the unnested output!
-            unnest_sql = f"""
-                SELECT "{id_col}",
-                       UNNEST(h3id) AS {h3_col}{parent_cols_str}
-                FROM (
-                    SELECT * FROM read_parquet('{intermediate_file}')
-                    LIMIT {self.intermediate_chunk_size} OFFSET {batch_offset}
-                )
-            """
+            if self.resolution_by_area is not None:
+                # Unnest to one cell per row first, then derive the union columns
+                # (which reference the per-row native_res alongside each cell).
+                unnest_sql = f"""
+                    SELECT "{id_col}", native_res, {union_cols_str}
+                    FROM (
+                        SELECT "{id_col}", native_res, UNNEST(h3id) AS cell
+                        FROM (
+                            SELECT * FROM read_parquet('{intermediate_file}')
+                            LIMIT {self.intermediate_chunk_size} OFFSET {batch_offset}
+                        )
+                    )
+                """
+            else:
+                unnest_sql = f"""
+                    SELECT "{id_col}",
+                           UNNEST(h3id) AS {h3_col}{parent_cols_str}
+                    FROM (
+                        SELECT * FROM read_parquet('{intermediate_file}')
+                        LIMIT {self.intermediate_chunk_size} OFFSET {batch_offset}
+                    )
+                """
 
             # Build up local file with fast local disk I/O
             if batch_id == 0:

--- a/docs/vector_processing.md
+++ b/docs/vector_processing.md
@@ -73,7 +73,8 @@ This prevents OOM errors when processing large polygons at high H3 resolutions. 
 
 - `input_url` (str): Path to input GeoParquet file
 - `output_url` (str): Path to output directory
-- `h3_resolution` (int): Primary H3 resolution (default: 10)
+- `h3_resolution` (int): Primary H3 resolution (default: 10). Ignored when `resolution_by_area` is set.
+- `resolution_by_area` (list[tuple], optional): Variable resolution per feature, parsed from a `--resolution-by-area` spec (see [Variable Resolution by Area](#variable-resolution-by-area)). Mutually exclusive with `h3_resolution`.
 - `parent_resolutions` (list[int]): Parent resolutions for aggregation (default: [9, 8, 0])
 - `chunk_size` (int): Number of rows to process at once in Pass 1 (default: 500)
 - `intermediate_chunk_size` (int): Number of array rows to unnest at once in Pass 2 (default: 10)
@@ -118,6 +119,51 @@ processor = H3VectorProcessor(
     intermediate_chunk_size=5  # Reduced from default 10
 )
 ```
+
+## Variable Resolution by Area
+
+**When to use this.** Reach for `--resolution-by-area` when a single dataset mixes
+small and very large polygons and a uniform fine resolution either OOMs in Pass 2
+or trips the 2 GB parquet-page limit on the biggest features — but dropping the
+*whole* dataset to a coarse resolution would throw away edge precision on the many
+small features. The canonical case is a species-range or protected-areas layer
+where a handful of continental/global polygons dominate cost while most features
+are small. If all your features are a similar size, keep using `--resolution`.
+
+Each feature is hexed at the native H3 resolution its **planar `ST_Area`** (deg²;
+≈12,000 km² per deg² at the equator) maps to — coarser bins for bigger features:
+
+```bash
+cng-datasets vector \
+    --input s3://bucket/ranges.parquet \
+    --output s3://bucket/ranges/chunks \
+    --resolution-by-area "12:8,600:6,5" \
+    --parent-resolutions "7,6,5,4,0"
+# area ≤ 12 deg²  -> res 8
+# area ≤ 600 deg² -> res 6
+# otherwise       -> res 5   (the trailing bare integer is the required catch-all)
+```
+
+**Output schema.** The result is a single uniform *union schema* — one `h{r}`
+column for every resolution in `{native resolutions} ∪ {parent_resolutions}`
+(capped at the finest native resolution) — plus a `native_res` column giving each
+row's true resolution. Finer columns are `NULL` in coarser tiers; the coarsest
+native resolution is non-null in every row, so flat equality joins still work
+across the mixed-resolution union (no compaction / ancestor-walks needed).
+
+**Requirements & notes.**
+- Include `0` in `--parent-resolutions` — it is the `h0` hive partition key (the
+  tool errors clearly if you omit it).
+- Mutually exclusive with `--resolution` / `--h3-resolution`.
+- The [oversized-feature guardrail](#memory-optimization) estimates cells at each
+  feature's *own* native resolution, so a polygon that would exceed the per-feature
+  cell-array limit at a fine resolution passes once a coarse bin is assigned.
+- **Chunk-size caveat:** because larger features are hexed coarser, cells-per-feature
+  still *rises* with the tier, so coarser/larger-feature tiers want a *smaller*
+  `--chunk-size` (aim for a roughly constant few-million cells per chunk, not a
+  constant row count). Automatic cells-per-chunk scaling is tracked in issue #124.
+- For a *single* feature too large even for the coarsest bin, see issue #125
+  (recursive classify-and-descend) — not yet implemented.
 
 ## Output Format
 

--- a/tests/test_k8s_workflows.py
+++ b/tests/test_k8s_workflows.py
@@ -159,6 +159,39 @@ class TestWorkflowGeneration:
             assert job["spec"]["completionMode"] == "Indexed"
     
     @pytest.mark.timeout(30)
+    def test_hex_job_resolution_by_area(self):
+        """Issue #98: --resolution-by-area is emitted into the hex job command in
+        place of --resolution, and geometry-type auto-detection is skipped."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            generate_dataset_workflow(
+                dataset_name="byarea-ds",
+                source_url="https://s3-west.nrp-nautilus.io/public-test/fixtures/test-fixture.gpkg",
+                bucket="test-bucket",
+                output_dir=tmpdir,
+                resolution_by_area="12:8,600:6,5",
+                parent_resolutions=[7, 6, 5, 4, 0],
+            )
+            hex_file = Path(tmpdir) / "byarea-ds-hex.yaml"
+            with open(hex_file) as f:
+                job = yaml.safe_load(f)
+            command_str = str(job["spec"]["template"]["spec"]["containers"][0]["command"])
+            assert '--resolution-by-area "12:8,600:6,5"' in command_str
+            assert "--resolution " not in command_str
+            assert "--parent-resolutions 7,6,5,4,0" in command_str
+
+    def test_resolution_by_area_rejects_bad_spec(self):
+        """A malformed spec fails fast during workflow generation."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            with pytest.raises(ValueError):
+                generate_dataset_workflow(
+                    dataset_name="bad-ds",
+                    source_url="https://s3-west.nrp-nautilus.io/public-test/fixtures/test-fixture.gpkg",
+                    bucket="test-bucket",
+                    output_dir=tmpdir,
+                    resolution_by_area="12:8,600:6",  # no catch-all
+                )
+
+    @pytest.mark.timeout(30)
     @pytest.mark.integration
     def test_hex_job_real_bucket(self):
         """Test hex job with real public bucket calculates proper chunking."""

--- a/tests/test_vector.py
+++ b/tests/test_vector.py
@@ -7,8 +7,9 @@ from pathlib import Path
 import os
 from unittest.mock import patch
 
-from cng_datasets.vector.h3_tiling import geom_to_h3_cells, setup_duckdb_connection, H3VectorProcessor, identify_id_column
+from cng_datasets.vector.h3_tiling import geom_to_h3_cells, setup_duckdb_connection, H3VectorProcessor, identify_id_column, parse_resolution_by_area
 from cng_datasets.vector.repartition import repartition_by_h0
+from cng_datasets.hex_checks import assert_h3_columns_unsigned
 from cng_datasets.storage.s3 import configure_s3_credentials
 
 
@@ -1261,5 +1262,220 @@ class TestRepartitionWithAttributeJoin:
                     output_dir=output_dir,
                     cleanup=False,
                 )
+
+
+class TestParseResolutionByArea:
+    """Issue #98: parsing the --resolution-by-area spec into sorted bins."""
+
+    def test_valid_spec_sorts_and_appends_catchall(self):
+        # Intentionally out of order to confirm threshold sorting.
+        bins = parse_resolution_by_area("600:6,12:8,5")
+        assert bins == [(12.0, 8), (600.0, 6), (None, 5)]
+
+    def test_single_catchall_only(self):
+        assert parse_resolution_by_area("7") == [(None, 7)]
+
+    def test_missing_catchall_raises(self):
+        with pytest.raises(ValueError, match="catch-all"):
+            parse_resolution_by_area("12:8,600:6")
+
+    def test_multiple_catchalls_raise(self):
+        with pytest.raises(ValueError, match="more than one catch-all"):
+            parse_resolution_by_area("12:8,5,3")
+
+    def test_empty_spec_raises(self):
+        with pytest.raises(ValueError, match="Empty"):
+            parse_resolution_by_area("")
+
+    def test_non_numeric_bin_raises(self):
+        with pytest.raises(ValueError, match="Invalid"):
+            parse_resolution_by_area("12:8,9:bad,5")
+
+    def test_resolution_out_of_range_raises(self):
+        with pytest.raises(ValueError, match="out of range"):
+            parse_resolution_by_area("12:99,5")
+
+    def test_duplicate_threshold_raises(self):
+        with pytest.raises(ValueError, match="duplicate threshold"):
+            parse_resolution_by_area("12:8,12:6,5")
+
+
+class TestResolutionByArea:
+    """Issue #98: variable-resolution (size-stratified) H3 polyfill.
+
+    Each feature is hexed at the native resolution its planar ST_Area maps to;
+    output carries a union schema (finer columns NULL in coarser tiers) plus a
+    native_res column, with the coarsest native resolution acting as a common
+    floor present in every row.
+    """
+
+    # area 0.0001 deg² -> res 8; area 100 -> res 6; area 2250 -> res 5
+    _SPEC = "1:8,600:6,5"
+    _PARENTS = [7, 6, 5, 4, 0]
+
+    def _make_source(self, tmpdir):
+        src = f"{tmpdir}/polys.parquet"
+        con = setup_duckdb_connection()
+        con.execute(f"""
+            COPY (SELECT * FROM (VALUES
+                (1, 'small',  ST_GeomFromText('POLYGON((0 0,0 0.01,0.01 0.01,0.01 0,0 0))')),
+                (2, 'medium', ST_GeomFromText('POLYGON((10 10,10 20,20 20,20 10,10 10))')),
+                (3, 'large',  ST_GeomFromText('POLYGON((40 0,40 45,90 45,90 0,40 0))'))
+            ) AS v(_cng_fid, name, geometry))
+            TO '{src}' (FORMAT PARQUET)
+        """)
+        con.close()
+        return src
+
+    @pytest.mark.timeout(15)
+    def test_geom_to_h3_cells_assigns_native_res(self):
+        """A tiny polygon is hexed fine (res 8); a huge one coarse (res 5)."""
+        con = setup_duckdb_connection()
+        con.execute("""
+            CREATE TABLE polys AS
+            SELECT * FROM (VALUES
+                (1, ST_GeomFromText('POLYGON((0 0,0 0.01,0.01 0.01,0.01 0,0 0))')),
+                (3, ST_GeomFromText('POLYGON((40 0,40 45,90 45,90 0,40 0))'))
+            ) AS v(_cng_fid, geom)
+        """)
+        bins = parse_resolution_by_area(self._SPEC)
+        sql = geom_to_h3_cells(con, "polys", keep_cols=['_cng_fid'], resolution_by_area=bins)
+        rows = con.execute(f"""
+            SELECT _cng_fid, native_res,
+                   h3_get_resolution(h3id[1]) AS cell_res
+            FROM ({sql}) ORDER BY _cng_fid
+        """).fetchall()
+        con.close()
+        by_fid = {r[0]: (r[1], r[2]) for r in rows}
+        assert by_fid[1] == (8, 8), "tiny polygon should be native res 8"
+        assert by_fid[3] == (5, 5), "huge polygon should be native res 5"
+
+    @pytest.mark.timeout(60)
+    def test_processor_emits_union_schema_and_native_res(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            src = self._make_source(tmpdir)
+            out = f"{tmpdir}/chunks"
+            os.makedirs(out)
+            processor = H3VectorProcessor(
+                input_url=src, output_url=out,
+                parent_resolutions=self._PARENTS, chunk_size=10,
+                intermediate_chunk_size=5,
+                resolution_by_area=parse_resolution_by_area(self._SPEC),
+            )
+            # finest bin resolution stands in for h3_resolution
+            assert processor.h3_resolution == 8
+            chunk_file = processor.process_chunk(0)
+            con = processor.con
+
+            cols = [d[0] for d in con.execute(
+                f"SELECT * FROM read_parquet('{chunk_file}') LIMIT 0").description]
+            assert cols == ['_cng_fid', 'native_res', 'h8', 'h7', 'h6', 'h5', 'h4', 'h0']
+
+            # native_res per feature
+            native = dict(con.execute(
+                f"SELECT DISTINCT _cng_fid, native_res FROM read_parquet('{chunk_file}')"
+            ).fetchall())
+            assert native == {1: 8, 2: 6, 3: 5}
+
+            # coarse-tier rows have NULL finer columns; common floor never NULL
+            nulls = con.execute(f"""
+                SELECT
+                    COUNT(*) FILTER (WHERE native_res = 5 AND h8 IS NOT NULL),
+                    COUNT(*) FILTER (WHERE native_res = 5 AND h6 IS NOT NULL),
+                    COUNT(*) FILTER (WHERE native_res = 6 AND h7 IS NOT NULL),
+                    COUNT(*) FILTER (WHERE h5 IS NULL),
+                    COUNT(*) FILTER (WHERE h0 IS NULL)
+                FROM read_parquet('{chunk_file}')
+            """).fetchone()
+            assert nulls == (0, 0, 0, 0, 0), (
+                "coarse tiers must NULL their finer columns; the common floor (h5) "
+                "and partition column (h0) must be non-null in every row"
+            )
+
+            # the native cell column equals native_res's resolution for every row
+            bad = con.execute(f"""
+                SELECT COUNT(*) FROM read_parquet('{chunk_file}')
+                WHERE h3_get_resolution(
+                    CASE native_res WHEN 8 THEN h8 WHEN 6 THEN h6 WHEN 5 THEN h5 END
+                ) <> native_res
+            """).fetchone()[0]
+            assert bad == 0
+
+            # all physical h{N>=1} columns are UBIGINT (issue #102)
+            assert_h3_columns_unsigned(
+                lambda q: con.execute(q).fetchall(), chunk_file)
+            processor.con.close()
+
+    def test_missing_h0_partition_column_raises(self):
+        """By-area output must carry h0 (the hive partition key); omitting 0 from
+        --parent-resolutions fails fast with a clear error."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            with pytest.raises(ValueError, match="h0 partition column"):
+                H3VectorProcessor(
+                    input_url=f"{tmpdir}/x.parquet", output_url=tmpdir,
+                    parent_resolutions=[7, 6, 5],  # no 0
+                    resolution_by_area=parse_resolution_by_area(self._SPEC),
+                )
+
+    @pytest.mark.timeout(60)
+    def test_parent_finer_than_finest_native_is_dropped(self):
+        """A parent resolution finer than the finest native bin would be an
+        all-NULL column, so it is not emitted (matches the fixed-res path)."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            src = self._make_source(tmpdir)
+            out = f"{tmpdir}/chunks"
+            os.makedirs(out)
+            processor = H3VectorProcessor(
+                input_url=src, output_url=out,
+                parent_resolutions=[9, 8, 0],  # 9 > finest native (8)
+                chunk_size=10, intermediate_chunk_size=5,
+                resolution_by_area=parse_resolution_by_area(self._SPEC),
+            )
+            chunk_file = processor.process_chunk(0)
+            cols = [d[0] for d in processor.con.execute(
+                f"SELECT * FROM read_parquet('{chunk_file}') LIMIT 0").description]
+            assert 'h9' not in cols, "all-null h9 (finer than finest native) must be dropped"
+            # attributes (name) are rejoined later in repartition, not in the chunk
+            assert cols == ['_cng_fid', 'native_res', 'h8', 'h6', 'h5', 'h0']
+            processor.con.close()
+
+    @pytest.mark.timeout(60)
+    def test_oversized_feature_backs_off_to_native_res(self):
+        """A feature that would exceed the #107 limit at the finest resolution
+        passes when its area assigns it a coarse native resolution."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            con = setup_duckdb_connection()
+            src = f"{tmpdir}/big.parquet"
+            con.execute(f"""
+                COPY (SELECT 3 AS _cng_fid,
+                             ST_GeomFromText('POLYGON((40 0,40 45,90 45,90 0,40 0))') AS geom)
+                TO '{src}' (FORMAT PARQUET)
+            """)
+            con.close()
+
+            # Fixed res 8: estimate far exceeds the (lowered) limit -> raises.
+            fixed = H3VectorProcessor(
+                input_url=src, output_url=f"{tmpdir}/o1",
+                h3_resolution=8, parent_resolutions=[0], chunk_size=10,
+            )
+            fixed.max_cells_per_feature = 1_000_000
+            with pytest.raises(RuntimeError, match=r"_cng_fid=3 is too large.*resolution 8"):
+                fixed._process_pass1(0)
+            fixed.con.close()
+
+            # By-area assigns res 5: estimate is well under the same limit -> passes.
+            os.makedirs(f"{tmpdir}/o2")
+            byarea = H3VectorProcessor(
+                input_url=src, output_url=f"{tmpdir}/o2",
+                parent_resolutions=[5, 4, 0], chunk_size=10, intermediate_chunk_size=5,
+                resolution_by_area=parse_resolution_by_area(self._SPEC),
+            )
+            byarea.max_cells_per_feature = 1_000_000
+            chunk_file = byarea.process_chunk(0)
+            assert chunk_file is not None
+            n = byarea.con.execute(
+                f"SELECT COUNT(*) FROM read_parquet('{chunk_file}')").fetchone()[0]
+            assert n > 0
+            byarea.con.close()
 
 


### PR DESCRIPTION
Closes #98 (Plan A). Implements the proven **size-stratified** ("Plan A") variable-resolution H3 hex documented in the #98 comment — the recipe behind the published `iucn-ranges-2025/hex` product (4.077 B rows, 122 partitions).

## What

A new `--resolution-by-area` option hexes each feature at the native H3 resolution its **planar `ST_Area`** maps to, so very large polygons use a coarse resolution while small ones keep fine edges. This avoids both failure modes uniform fine resolution hits on giant marine ranges — the Pass-2 OOM and the 2 GB parquet-page assertion (guarded by #107) — **without** dropping the whole dataset to a coarse resolution.

```
cng-datasets vector --input … --output … \
  --resolution-by-area "12:8,600:6,5" --parent-resolutions "7,6,5,4,0"
# area ≤ 12 deg² → res 8;  ≤ 600 → res 6;  else res 5 (trailing catch-all)
```

## How

- **`parse_resolution_by_area`** — parses `"12:8,600:6,5"` into sorted bins + a required catch-all; rejects empty / missing-catch-all / multiple-catch-all / duplicate-threshold / out-of-range specs.
- **`geom_to_h3_cells`** — new per-feature path: a `native_res` CASE on `ST_Area` feeds the H3 polyfill (DuckDB accepts a per-row resolution arg), with line buffering tracking each feature's `native_res`. The fixed-resolution path is left byte-for-byte unchanged.
- **Pass 2** — emits a uniform **union schema**: one `h{r}` column per resolution in `{native} ∪ {parents}` (capped at the finest native; finer columns `NULL` in coarser tiers) plus a `native_res` column. The coarsest native resolution is non-null in every row, preserving flat equality joins. Schema is uniform across chunks → **repartition unaffected** (verified end-to-end).
- **#107 guard** — now estimates cells at each feature's *own* native resolution, so large features back off automatically (the per-feature back-off the meta-issue calls the complement to #107's guardrail).
- **CLI / workflow** — `--resolution-by-area` on the `vector` and `workflow` commands (mutually exclusive with `--resolution` / `--h3-resolution`), threaded into the generated hex job. Requires `0` in `--parent-resolutions` for the h0 partition column (validated with a clear error).

## Deferred (follow-ups under #98)

- Cells-per-chunk auto-scaling (`--chunk-size` should scale inversely with feature size — the "Key lesson" in the #98 comment).
- Recursive classify-and-descend polyfill for a *single* feature too big even for the coarse tier.

## Testing

- New `TestParseResolutionByArea` and `TestResolutionByArea` in `tests/test_vector.py`: parsing edge cases; per-feature native_res assignment; union schema + null pattern + UBIGINT (#102); common-floor non-null; per-feature #107 back-off; missing-h0 error; all-null parent column dropped.
- New workflow tests assert `--resolution-by-area` is emitted into the hex job and bad specs fail fast.
- Full `tests/test_vector.py` + `TestWorkflowGeneration` pass locally (70 passed); ruff CI gate (`--select E,F,W --ignore E501`) clean. (Raster/`osgeo` and `pytest-mock` suites can't run in this local env — unchanged from `main`.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)