### PR TITLE
fix: cap duckdb <1.5.4 so h3 community extension resolves in Docker build

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,7 +13,11 @@ authors = [
     {name = "Boettiger Lab", email = "cboettig@berkeley.edu"}
 ]
 dependencies = [
-    "duckdb>=0.10.0",
+    # Cap below 1.5.4: the `h3` community extension (installed fresh in the
+    # Dockerfile) is not yet published for 1.5.4, so `INSTALL h3 FROM community`
+    # 404s and breaks the image build. 1.5.3 is the tested standard. Raise the
+    # ceiling once the h3 community build catches up to the newer release.
+    "duckdb>=0.10.0,<1.5.4",
     "ibis-framework[duckdb]>=9.0.0",
     "polars>=0.20.0",
     "pyarrow>=15.0.0",


### PR DESCRIPTION
## Problem

The **Build and Publish Docker Image** workflow on `main` is failing (since the #123 merge push, but unrelated to that change). DuckDB just released **1.5.4**; `pyproject.toml` had an unpinned `duckdb>=0.10.0`, so the image build resolved to 1.5.4. The Dockerfile installs the `h3` community extension fresh at build time:

```
RUN python3 -c "... con.execute('INSTALL h3 FROM community')"
```

and h3 is **not yet published for 1.5.4**, so the install 404s and the build fails:

```
HTTP Error: Failed to download extension "h3" at URL
".../v1.5.4/linux_amd64/h3.duckdb_extension.gz" (HTTP 404)
```

This is an upstream "community extension lags the DuckDB release" issue — it would break any push to `main`, and is independent of the `--resolution-by-area` work. Tests and lint were green throughout; only the push-to-main Docker publish (which doesn't run on PRs) was affected.

## Fix

Cap the dependency below 1.5.4: `duckdb>=0.10.0,<1.5.4`. 1.5.3 is the tested standard and ships a working h3 (verified locally). Raise the ceiling once the community h3 build catches up to the newer release.

## Note (out of scope)

`uv.lock` is stale relative to the 0.2.0 release (still records v0.1.1 and pre-#84 raster deps). The Docker build uses `uv pip install -e ".[raster]"` (fresh resolution, not the lock), so it doesn't affect this fix — but the lock is worth regenerating separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)