### PR TITLE
fix(#128): force (lon,lat) via ST_Transform always_xy

### DIFF
--- a/cng_datasets/vector/convert_to_parquet.py
+++ b/cng_datasets/vector/convert_to_parquet.py
@@ -359,6 +359,17 @@ def is_geographic_crs(crs: str) -> bool:
     Returns:
         True if geographic, False if projected
     """
+    # Prefer pyproj, which correctly classifies compound and geographic-3D CRSs
+    # (e.g. EPSG:5498 "NAD83 + NAVD88 height", EPSG:4979). A numeric range check
+    # cannot: 5498 >= 5000 looks projected but is geographic, and flipping its
+    # axes on a geographic->geographic transform corrupts coordinates (see #128).
+    try:
+        from pyproj import CRS
+        return bool(CRS.from_user_input(crs).is_geographic)
+    except Exception:
+        pass
+
+    # Fallback heuristic if pyproj is unavailable or the CRS string is unparseable.
     # Common geographic CRS codes
     if crs in ["EPSG:4326", "EPSG:4269", "EPSG:4267"]:
         return True

--- a/cng_datasets/vector/convert_to_parquet.py
+++ b/cng_datasets/vector/convert_to_parquet.py
@@ -349,44 +349,6 @@ def get_geometry_column(source_url: str, layer: Optional[str] = None, verbose: b
         con.close()
 
 
-def is_geographic_crs(crs: str) -> bool:
-    """
-    Check if a CRS is geographic (uses degrees) vs projected (uses meters).
-
-    Args:
-        crs: CRS string (e.g., "EPSG:4326")
-
-    Returns:
-        True if geographic, False if projected
-    """
-    # Prefer pyproj, which correctly classifies compound and geographic-3D CRSs
-    # (e.g. EPSG:5498 "NAD83 + NAVD88 height", EPSG:4979). A numeric range check
-    # cannot: 5498 >= 5000 looks projected but is geographic, and flipping its
-    # axes on a geographic->geographic transform corrupts coordinates (see #128).
-    try:
-        from pyproj import CRS
-        return bool(CRS.from_user_input(crs).is_geographic)
-    except Exception:
-        pass
-
-    # Fallback heuristic if pyproj is unavailable or the CRS string is unparseable.
-    # Common geographic CRS codes
-    if crs in ["EPSG:4326", "EPSG:4269", "EPSG:4267"]:
-        return True
-
-    # Extract EPSG code
-    if crs.startswith("EPSG:"):
-        try:
-            code = int(crs.split(":")[1])
-            # EPSG codes 4000-4999 are typically geographic
-            if 4000 <= code < 5000:
-                return True
-        except (ValueError, IndexError):
-            pass
-
-    return False
-
-
 def check_id_column(source_url: str, layer: Optional[str] = None, id_column: Optional[str] = None,
                     force_id: bool = True, verbose: bool = False) -> Tuple[bool, str]:
     """
@@ -472,15 +434,19 @@ def build_read_reproject_query(source_inputs: Union[str, List[str]], source_crs:
 
     # Determine geometry transformation
     if source_crs and source_crs != target_crs:
-        # Need to reproject
-        if is_geographic_crs(target_crs) and not is_geographic_crs(source_crs):
-            # Projected → geographic: DuckDB's ST_Transform outputs (lat, lon) authority
-            # axis order, but GeoParquet requires (lon, lat). Apply ST_FlipCoordinates.
-            # Geographic → geographic (e.g. EPSG:4269 → EPSG:4326): ST_Transform preserves
-            # traditional (lon, lat) order, so no flip is needed.
-            geom_expr = f"ST_FlipCoordinates(ST_Transform({raw_geom}, '{source_crs}', '{target_crs}')) AS {geom_col}"
-        else:
-            geom_expr = f"ST_Transform({raw_geom}, '{source_crs}', '{target_crs}') AS {geom_col}"
+        # Need to reproject. DuckDB's ST_Transform honours each CRS's *authority* axis
+        # order by default (e.g. EPSG:4326 is latitude-first), but GeoParquet — and
+        # DuckDB's own ST_Read — always store coordinates as (longitude, latitude).
+        # Passing always_xy := true forces ST_Transform to read AND write (lon, lat)
+        # regardless of either CRS's declared axis order, so the output is always
+        # (lon, lat) and no ST_FlipCoordinates correction is needed.
+        #
+        # This replaces an earlier is_geographic_crs() heuristic that decided whether
+        # to flip based on a numeric EPSG-code range. That heuristic mis-handled
+        # axis-order edge cases — geographic CRSs that are longitude-first (OGC:CRS84)
+        # and geographic compound/3D CRSs with codes >= 5000 (EPSG:5498
+        # "NAD83 + NAVD88 height", EPSG:4979) — swapping lat/lon for them (see #128).
+        geom_expr = f"ST_Transform({raw_geom}, '{source_crs}', '{target_crs}', always_xy := true) AS {geom_col}"
     else:
         # No reprojection needed; DuckDB ST_Read returns (lon, lat) for all formats
         geom_expr = f"{raw_geom} AS {geom_col}" if geom_is_blob else geom_col

--- a/tests/test_convert_to_parquet.py
+++ b/tests/test_convert_to_parquet.py
@@ -67,6 +67,32 @@ class TestReprojectQueryAxisOrder:
         finally:
             con.close()
 
+    def test_compound_crs_to_crs84_target_is_valid_and_finite(self):
+        """EPSG:5498 -> OGC:CRS84 must yield valid, finite geometry.
+
+        #128 noted that --target-crs OGC:CRS84 produced corrupt geometry (xmax=inf,
+        most features invalid). That is the same axis-order root cause: without
+        always_xy, ST_Transform read the stored (lon, lat) as 5498's authority
+        (lat, lon), feeding an out-of-range "latitude" into PROJ and blowing up to
+        infinity. always_xy := true fixes the EPSG:4326 and OGC:CRS84 targets alike.
+        """
+        con = duckdb.connect()
+        con.install_extension("spatial")
+        con.load_extension("spatial")
+        try:
+            wkt = "POLYGON((-118.3 33.8,-118.1 33.8,-118.1 34.0,-118.3 34.0,-118.3 33.8))"
+            valid, xmax, ymax = con.execute(f"""
+                SELECT ST_IsValid(g), ST_XMax(g), ST_YMax(g) FROM (
+                    SELECT ST_Transform(ST_GeomFromText('{wkt}'),
+                                        'EPSG:5498', 'OGC:CRS84', always_xy := true) AS g
+                )
+            """).fetchone()
+            assert valid, "transform to OGC:CRS84 produced invalid geometry"
+            assert xmax < 0 and xmax > -119, f"xmax {xmax} not a finite CA longitude"
+            assert 33 < ymax < 35, f"ymax {ymax} not a finite CA latitude"
+        finally:
+            con.close()
+
 
 class TestConvertToParquet:
     """Test convert_to_parquet functionality."""

--- a/tests/test_convert_to_parquet.py
+++ b/tests/test_convert_to_parquet.py
@@ -6,7 +6,38 @@ import tempfile
 import os
 from pathlib import Path
 import duckdb
-from cng_datasets.vector.convert_to_parquet import convert_to_parquet
+from cng_datasets.vector.convert_to_parquet import convert_to_parquet, is_geographic_crs
+
+
+class TestIsGeographicCRS:
+    """Unit tests for is_geographic_crs CRS classification."""
+
+    @pytest.mark.parametrize("crs", [
+        "EPSG:4326",   # WGS84
+        "EPSG:4269",   # NAD83 (Census TIGER)
+        "EPSG:4267",   # NAD27
+        "EPSG:4979",   # WGS84 geographic 3D
+        "EPSG:5498",   # NAD83 + NAVD88 height — compound geographic (#128)
+        "OGC:CRS84",   # WGS84 (lon, lat)
+    ])
+    def test_geographic_crs_classified_true(self, crs):
+        assert is_geographic_crs(crs) is True
+
+    @pytest.mark.parametrize("crs", [
+        "EPSG:3857",   # Web Mercator
+        "EPSG:32610",  # UTM zone 10N
+        "EPSG:5070",   # CONUS Albers — code >= 5000, projected
+    ])
+    def test_projected_crs_classified_false(self, crs):
+        assert is_geographic_crs(crs) is False
+
+    def test_compound_geographic_crs_not_flipped(self):
+        """Regression for #128: EPSG:5498 (>= 5000) is geographic, not projected.
+
+        Misclassifying it as projected made the projected->geographic branch apply
+        ST_FlipCoordinates to a geographic->geographic transform, swapping lat/lon.
+        """
+        assert is_geographic_crs("EPSG:5498") is True
 
 
 class TestConvertToParquet:

--- a/tests/test_convert_to_parquet.py
+++ b/tests/test_convert_to_parquet.py
@@ -6,38 +6,66 @@ import tempfile
 import os
 from pathlib import Path
 import duckdb
-from cng_datasets.vector.convert_to_parquet import convert_to_parquet, is_geographic_crs
+from cng_datasets.vector.convert_to_parquet import (
+    convert_to_parquet,
+    build_read_reproject_query,
+)
 
 
-class TestIsGeographicCRS:
-    """Unit tests for is_geographic_crs CRS classification."""
+class TestReprojectQueryAxisOrder:
+    """Axis-order handling in the read/reproject query (regression for #128).
 
-    @pytest.mark.parametrize("crs", [
-        "EPSG:4326",   # WGS84
-        "EPSG:4269",   # NAD83 (Census TIGER)
-        "EPSG:4267",   # NAD27
+    DuckDB's ST_Transform honours each CRS's authority axis order by default
+    (EPSG:4326 is latitude-first), while GeoParquet always stores (lon, lat).
+    The query passes always_xy := true so ST_Transform reads and writes (lon, lat)
+    for every CRS, which removes the need for ST_FlipCoordinates and fixes the
+    lat/lon swap that the old numeric is_geographic_crs() heuristic produced for
+    geographic compound CRSs such as EPSG:5498 ("NAD83 + NAVD88 height").
+    """
+
+    @pytest.mark.parametrize("source_crs", [
+        "EPSG:5498",   # NAD83 + NAVD88 height — compound geographic, code >= 5000 (#128)
+        "EPSG:4269",   # NAD83 (Census TIGER), latitude-first geographic
+        "OGC:CRS84",   # WGS84 longitude-first geographic
         "EPSG:4979",   # WGS84 geographic 3D
-        "EPSG:5498",   # NAD83 + NAVD88 height — compound geographic (#128)
-        "OGC:CRS84",   # WGS84 (lon, lat)
+        "EPSG:3310",   # CA Albers, projected
     ])
-    def test_geographic_crs_classified_true(self, crs):
-        assert is_geographic_crs(crs) is True
+    def test_reproject_uses_always_xy_and_never_flips(self, source_crs):
+        sql = build_read_reproject_query(
+            "dummy.gdb", source_crs=source_crs, target_crs="EPSG:4326", geom_col="geom"
+        )
+        assert "always_xy := true" in sql, "ST_Transform must force (lon, lat) axis order"
+        assert "ST_FlipCoordinates" not in sql, (
+            "No coordinate flip should be emitted; always_xy already yields (lon, lat)"
+        )
 
-    @pytest.mark.parametrize("crs", [
-        "EPSG:3857",   # Web Mercator
-        "EPSG:32610",  # UTM zone 10N
-        "EPSG:5070",   # CONUS Albers — code >= 5000, projected
-    ])
-    def test_projected_crs_classified_false(self, crs):
-        assert is_geographic_crs(crs) is False
+    def test_no_reprojection_when_source_equals_target(self):
+        sql = build_read_reproject_query(
+            "dummy.gpkg", source_crs="EPSG:4326", target_crs="EPSG:4326", geom_col="geom"
+        )
+        assert "ST_Transform" not in sql
 
-    def test_compound_geographic_crs_not_flipped(self):
-        """Regression for #128: EPSG:5498 (>= 5000) is geographic, not projected.
+    def test_compound_crs_transform_preserves_lon_lat(self):
+        """End-to-end ST_Transform check (no ogr2ogr needed): a point stored as
+        (lon, lat) in EPSG:5498 must remain (lon, lat) after transform to EPSG:4326.
 
-        Misclassifying it as projected made the projected->geographic branch apply
-        ST_FlipCoordinates to a geographic->geographic transform, swapping lat/lon.
+        This is the exact #128 scenario isolated to the transform DuckDB runs.
         """
-        assert is_geographic_crs("EPSG:5498") is True
+        con = duckdb.connect()
+        con.install_extension("spatial")
+        con.load_extension("spatial")
+        try:
+            # Compton Creek-ish point: lon=-118.2, lat=33.9 (stored x=lon, y=lat)
+            x, y = con.execute("""
+                SELECT ST_X(g), ST_Y(g) FROM (
+                    SELECT ST_Transform(ST_Point(-118.2, 33.9),
+                                        'EPSG:5498', 'EPSG:4326', always_xy := true) AS g
+                )
+            """).fetchone()
+            assert -119 < x < -117, f"X must be longitude ~-118, got {x:.3f} (lat/lon swapped)"
+            assert 33 < y < 35, f"Y must be latitude ~34, got {y:.3f} (lat/lon swapped)"
+        finally:
+            con.close()
 
 
 class TestConvertToParquet:
@@ -627,10 +655,9 @@ class TestReprojection:
         """
         Create a shapefile in EPSG:4269 (NAD83) — the CRS used by all Census TIGER files.
 
-        This is the real bug scenario: source is geographic (EPSG:4269), target is
-        EPSG:4326. reprojection is triggered because they differ, and the previous code
-        incorrectly applied ST_FlipCoordinates for all geographic targets — including
-        geographic→geographic transforms where ST_Transform does NOT swap axes.
+        Source is geographic (EPSG:4269), target is EPSG:4326; reprojection is
+        triggered because they differ. Exercises the always_xy := true transform
+        path, which must keep coordinates in (lon, lat) order.
         """
         import subprocess
         import json
@@ -679,9 +706,9 @@ class TestReprojection:
         """
         EPSG:4269 (NAD83) shapefile → EPSG:4326 must produce (lon, lat) = (X, Y).
 
-        This is the regression test for Census TIGER data. The bug: the old code applied
-        ST_FlipCoordinates for any geographic target CRS, but geographic→geographic
-        ST_Transform does NOT swap axes. The flip incorrectly put latitude values in X.
+        Regression test for Census TIGER data. ST_Transform is now invoked with
+        always_xy := true so it reads and writes (lon, lat) regardless of authority
+        axis order; the output must therefore keep longitude in X.
         """
         with tempfile.NamedTemporaryFile(suffix='.parquet', delete=False) as f:
             output_path = f.name
@@ -714,8 +741,8 @@ class TestReprojection:
             # X must be longitude (negative for US west coast), not latitude (~37)
             assert min_x < -100, (
                 f"X min is {min_x:.2f} — looks like latitude, not longitude. "
-                "Axis swap bug: ST_FlipCoordinates is being applied to a "
-                "geographic→geographic transform that doesn't need it."
+                "Axis swap bug: ST_Transform output is not (lon, lat) — check that "
+                "always_xy := true is set."
             )
             assert -123 <= min_x <= -122, f"X min {min_x:.2f} not in expected SF Bay Area lon range"
             assert -123 <= max_x <= -122, f"X max {max_x:.2f} not in expected SF Bay Area lon range"


### PR DESCRIPTION
## Summary

Fixes #128 (the `cng-convert-to-parquet` lat/lon swap for geographic compound CRSs such as **EPSG:5498** "NAD83 + NAVD88 height", used by the USGS WBD GDB).

The original report pinned the blame on `is_geographic_crs()` and suggested replacing its numeric-range heuristic with `pyproj.CRS.is_geographic`. **That fix is incorrect** — it classifies `OGC:CRS84(/h)` as geographic too, which would *stop* flipping a transform that DuckDB genuinely swaps, breaking the existing `test_3d_geometry_flattened_to_2d` (its source CRS is detected as `OGC:CRS84h`). I caught this in CI on the first attempt.

## Root cause (more general than #128)

DuckDB's `ST_Transform` honours each CRS's **authority axis order** by default — `EPSG:4326` is *latitude-first*, `OGC:CRS84` is *longitude-first*. GeoParquet (and DuckDB's own `ST_Read`) always store coordinates as **(longitude, latitude)**. So whether a post-transform `ST_FlipCoordinates` is needed depends on the *axis order* of both CRSs, not on geographic-vs-projected.

The old `is_geographic_crs()` predicted the flip from a numeric EPSG-code range (`4000–4999 ⇒ geographic`). That mishandles:
- geographic compound/3D CRSs with codes ≥ 5000 — **EPSG:5498**, EPSG:4979 (the #128 swap), and
- longitude-first geographic CRSs — **OGC:CRS84/CRS84h**.

Empirical source→target matrix (DuckDB 1.5.3, point stored as `(lon=-120, lat=38)`):

| source → target | default ST_Transform | `always_xy := true` |
|---|---|---|
| EPSG:4269 → 4326 | (-120, 38) ok | (-120, 38) ok |
| EPSG:5498 → 4326 | (-120, 38) ok | (-120, 38) ok |
| OGC:CRS84 → 4326 | **(38, -120) swapped** | (-120, 38) ok |
| OGC:CRS84h → 4326 | **(38, -120) swapped** | (-120, 38) ok |
| EPSG:3310 → 4326 | **(38, -120) swapped** | (-120, 38) ok |

The old heuristic + flip happened to be tuned for EPSG-authority geographic sources targeting 4326, but produced a flip for 5498 (#128) and no-flip for CRS84h (the regression my first attempt exposed).

## Fix

Pass `always_xy := true` to `ST_Transform`, which forces it to read **and** write `(lon, lat)` for every CRS — exactly GeoParquet's storage convention. The output is then always `(lon, lat)`, so `ST_FlipCoordinates` is never needed and the `is_geographic_crs()` heuristic is removed entirely.

Confirmed against DuckDB/PROJ + GeoParquet docs:
- DuckDB `ST_Transform` defaults to authority axis order; `always_xy := true` forces (lon, lat). ([duckdb-spatial functions](https://duckdb.org/docs/stable/core_extensions/spatial/functions))
- GeoParquet stores (lon, lat) regardless of CRS label; OGC:CRS84 and EPSG:4326 differ only in axis order. ([GeoParquet spec](https://github.com/opengeospatial/geoparquet/blob/main/format-specs/geoparquet.md))

## Tests

New `TestReprojectQueryAxisOrder` (runs without `ogr2ogr`):
- query emits `always_xy := true` and never `ST_FlipCoordinates`, for source CRSs EPSG:5498 / 4269 / OGC:CRS84 / 4979 / 3310;
- no `ST_Transform` when source == target;
- end-to-end DuckDB check that an EPSG:5498 point stays `(lon, lat)` after transform to EPSG:4326 (the isolated #128 scenario).

Existing `ogr2ogr`-backed reprojection tests (NAD83, projected, 3D/CRS84h, GeoJSON) still assert correct `(lon, lat)` output and now exercise the `always_xy` path. The remaining suite failures locally are pre-existing and `ogr2ogr`/GDAL-dependent (absent in this dev env; run in CI).

## Impact

Unblocks data-workflows#200 (USGS WBD national import) — all six HUC levels share EPSG:5498. The more general axis-order correctness also fixes longitude-first source CRSs (OGC:CRS84) and projected→geographic transforms uniformly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)