### PR TITLE
fix(#106): cap row-group bytes so geometry chunks stay httpfs-readable

### DIFF
--- a/cng_datasets/vector/convert_to_parquet.py
+++ b/cng_datasets/vector/convert_to_parquet.py
@@ -37,6 +37,21 @@ _CURVED_GEOMETRY_TYPES = frozenset({
 # Flattening to 2D with ogr2ogr before ST_Read avoids the BLOB issue entirely.
 _NON_2D_GEOMETRY_PATTERNS = ('3d ', 'measured', ' z', ' m', 'z,', 'm,')
 
+# Upper bound on the (uncompressed) size of a single Parquet row group, passed to
+# DuckDB's COPY as ROW_GROUP_SIZE_BYTES. This caps the per-column chunk size so
+# the geometry column never produces one giant chunk.
+#
+# Why this exists (issue #106): DuckDB's httpfs reader aborts with a bare
+# "Error: stoi" when it has to read a single Parquet column chunk larger than
+# ~2.85 GB — even though a local read of the exact same file decodes fine. The
+# row-count limit (ROW_GROUP_SIZE) can't prevent this because bytes-per-feature
+# varies enormously (full-precision FEMA/IUCN multipolygons run tens of KB each),
+# so the default 100k rows packs into one ~2.9 GB chunk that is unreadable over
+# S3/httpfs by the duckdb-mcp server. A 1 GB byte budget keeps chunks an order of
+# magnitude under the cliff regardless of geometry size. Verified against the
+# issue's MRE: the byte-capped file full-scans cleanly on the MCP.
+DEFAULT_ROW_GROUP_BYTES = "1GB"
+
 
 def _is_gdb_source(source_url: str) -> bool:
     """Check if source is a GDAL FileGDB or OpenFileGDB source."""
@@ -689,7 +704,8 @@ def write_with_duckdb(query: str, output_path: str,
                       compression: str = "ZSTD",
                       compression_level: int = 15,
                       row_group_size: int = 100000,
-                      verbose: bool = False) -> None:
+                      verbose: bool = False,
+                      row_group_bytes: str = DEFAULT_ROW_GROUP_BYTES) -> None:
     """
     Write parquet file using DuckDB COPY. Simple and reliable.
 
@@ -698,7 +714,13 @@ def write_with_duckdb(query: str, output_path: str,
         output_path: Local output file path
         compression: Compression algorithm
         compression_level: Compression level
-        row_group_size: Rows per group
+        row_group_size: Rows per group (upper bound on row count)
+        row_group_bytes: Upper bound on the uncompressed size of a row group
+            (DuckDB ROW_GROUP_SIZE_BYTES). A row group is flushed when EITHER
+            this byte budget or row_group_size is reached, so small datasets are
+            unaffected while a single huge-geometry column is split into several
+            chunks. This is what keeps the geometry column chunk small enough to
+            be read over httpfs (issue #106 — see DEFAULT_ROW_GROUP_BYTES).
         verbose: Print debug information
     """
     con = duckdb.connect(':memory:')
@@ -708,9 +730,16 @@ def write_with_duckdb(query: str, output_path: str,
     # Enable large buffer size for complex geometries (Total buffer > 2GB)
     con.execute("SET arrow_large_buffer_size=true")
 
+    # ROW_GROUP_SIZE_BYTES requires insertion order not to be preserved. Output
+    # row order carries no meaning here — every row has an explicit _cng_fid (or
+    # source id) that travels with it and is what downstream joins key on — so
+    # this is safe and lets DuckDB flush row groups on the byte budget.
+    con.execute("SET preserve_insertion_order=false")
+
     try:
         if verbose:
             print(f"  Writing with DuckDB to {output_path}...")
+            print(f"    row group cap: {row_group_size:,} rows / {row_group_bytes} bytes")
 
         # Use COPY - it works!
         con.execute(f"""
@@ -718,7 +747,8 @@ def write_with_duckdb(query: str, output_path: str,
             TO '{output_path}'
             (FORMAT PARQUET,
              COMPRESSION {compression},
-             ROW_GROUP_SIZE {row_group_size})
+             ROW_GROUP_SIZE {row_group_size},
+             ROW_GROUP_SIZE_BYTES '{row_group_bytes}')
         """)
 
         if verbose:

--- a/tests/test_convert_to_parquet.py
+++ b/tests/test_convert_to_parquet.py
@@ -9,6 +9,8 @@ import duckdb
 from cng_datasets.vector.convert_to_parquet import (
     convert_to_parquet,
     build_read_reproject_query,
+    write_with_duckdb,
+    DEFAULT_ROW_GROUP_BYTES,
 )
 
 
@@ -1258,3 +1260,76 @@ class TestMultipointGeometry:
                 )
             # Nothing should have been written.
             assert not os.path.exists(output_path)
+
+
+class TestRowGroupByteCap:
+    """The geometry column must be split into multiple row groups by a byte
+    budget, not just a row count (regression for #106).
+
+    DuckDB's httpfs reader aborts with "Error: stoi" on a single Parquet column
+    chunk larger than ~2.85 GB, so a full-precision geometry column packed into
+    one 100k-row group is unreadable over S3/the duckdb-mcp server. write_with_duckdb
+    passes ROW_GROUP_SIZE_BYTES so an oversized geometry column is chunked even
+    when the row count stays under ROW_GROUP_SIZE.
+    """
+
+    # A query producing non-trivial polygon geometry (each ~hundreds of vertices).
+    _GEOM_QUERY = (
+        "SELECT i AS _cng_fid, "
+        "ST_Buffer(ST_Point(i * 1.0, i * 1.0), 1.0, 60) AS geom "
+        "FROM range(8000) t(i)"
+    )
+
+    def _geom_row_groups(self, path):
+        con = duckdb.connect()
+        try:
+            return con.execute(
+                f"SELECT COUNT(*) FROM parquet_metadata('{path}') "
+                f"WHERE path_in_schema = 'geom'"
+            ).fetchone()[0]
+        finally:
+            con.close()
+
+    def test_byte_budget_splits_geometry_column(self):
+        """A small byte budget splits the geom column into more row groups than the
+        default, even with the row-count cap left effectively unlimited."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            capped = os.path.join(tmpdir, "capped.parquet")
+            default = os.path.join(tmpdir, "default.parquet")
+
+            # row_group_size huge so the BYTE budget is what governs the split.
+            write_with_duckdb(self._GEOM_QUERY, capped,
+                              row_group_size=10_000_000, row_group_bytes="256kB")
+            write_with_duckdb(self._GEOM_QUERY, default,
+                              row_group_size=10_000_000)  # default 1GB budget
+
+            capped_groups = self._geom_row_groups(capped)
+            default_groups = self._geom_row_groups(default)
+
+            assert default_groups == 1, (
+                f"small data should fit one row group at the default {DEFAULT_ROW_GROUP_BYTES} "
+                f"budget, got {default_groups}"
+            )
+            assert capped_groups > default_groups, (
+                f"byte budget must split the geom column: capped={capped_groups} "
+                f"default={default_groups}"
+            )
+
+    def test_byte_cap_preserves_all_rows_and_unique_ids(self):
+        """Splitting (and the preserve_insertion_order=false it requires) must not
+        drop, duplicate, or corrupt rows; _cng_fid stays row-unique."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            out = os.path.join(tmpdir, "capped.parquet")
+            write_with_duckdb(self._GEOM_QUERY, out,
+                              row_group_size=10_000_000, row_group_bytes="256kB")
+
+            con = duckdb.connect()
+            try:
+                total, distinct = con.execute(
+                    f"SELECT COUNT(*), COUNT(DISTINCT _cng_fid) FROM read_parquet('{out}')"
+                ).fetchone()
+            finally:
+                con.close()
+
+            assert total == 8000, f"expected all 8000 rows, got {total}"
+            assert distinct == 8000, f"_cng_fid must stay row-unique, got {distinct} distinct"


### PR DESCRIPTION
Closes #106.

## What

Pass `ROW_GROUP_SIZE_BYTES` (default **1 GB**) to the convert-step `COPY`, so an oversized geometry column is split into several sub-GB Parquet column chunks instead of one giant chunk. Centralised in `write_with_duckdb`, so **both** convert paths (`ST_Read` and parquet-input) are covered.

## Why

`cng-convert`'s output of full-precision FEMA/IUCN geometry was unreadable on the `duckdb-mcp` server — any query touching the geometry column aborted with a bare `Error: stoi`.

Root cause (full diagnosis in #106): **DuckDB's httpfs reader aborts on a single Parquet column chunk larger than ~2.85 GB**, even though a local read of the identical file decodes correctly. It is *not* a CRS-tag, writer, or bad-geometry defect — reproduced with `duckdb 1.5.3` + `httpfs` only, no spatial extension, on a plain `BLOB` column (filed upstream against `duckdb/duckdb`).

The row-count cap (`ROW_GROUP_SIZE = 100000`) can't prevent this: bytes-per-feature vary enormously (full-precision multipolygons run tens of KB each), so 100k features packed into one ~2.9 GB chunk. A byte budget bounds the chunk directly regardless of geometry size; 1 GB keeps chunks an order of magnitude under the cliff.

## Validation

Against the issue's MRE (`repro-100000.parquet`, one 2.9 GB geom chunk → `stoi` on the MCP): the byte-capped re-encode (4 chunks, ≤0.81 GB compressed) **full-scans cleanly on the MCP**. Bisection showed the cliff at ~2.8–2.88 GB compressed and that chunking the *same data* (same file size) fixes it, ruling out file size / byte offset.

## Notes

- `ROW_GROUP_SIZE_BYTES` requires `preserve_insertion_order=false`. Output row order is meaningless here — every row keys on its own `_cng_fid` (or source id), which travels with the row — so this is safe. Order-sensitive tests already `ORDER BY _cng_fid`.
- New tests (`TestRowGroupByteCap`) assert the byte budget splits the geom column and preserves all rows / unique ids. The 6 local failures in the suite are the pre-existing missing-`ogr2ogr` env limitation, unrelated to this change.
- **Follow-up (not in scope):** `repartition.py` also writes full geometry (partitioned by `h0`); a dense partition could in principle hit the same cliff. No reproducer yet — worth applying the same `ROW_GROUP_SIZE_BYTES` guard there if one surfaces.
