### PR TITLE
fix(#134,#130,#131): duckdb bump, GDB-in-zip support, non-EPSG SRS crash

### DIFF
--- a/cng_datasets/raster/cog.py
+++ b/cng_datasets/raster/cog.py
@@ -671,7 +671,10 @@ def create_mosaic_cog(
             print(f"  ⚠ Could not open {vsi_url}, skipping")
             continue
         srs = osr.SpatialReference(wkt=ds.GetProjection())
-        srs.AutoIdentifyEPSG()
+        try:
+            srs.AutoIdentifyEPSG()
+        except RuntimeError:
+            pass  # no EPSG authority code (e.g. ESRI:102003); proceed with WKT/PROJ definition
         epsg = srs.GetAuthorityCode(None)
         crs_key = f"EPSG:{epsg}" if epsg else srs.ExportToProj4()
         ds = None
@@ -920,7 +923,10 @@ class RasterProcessor:
             _srs = osr.SpatialReference(wkt=_ds.GetProjection())
             _ds = None
             if not _srs.IsGeographic():
-                _srs.AutoIdentifyEPSG()
+                try:
+                    _srs.AutoIdentifyEPSG()
+                except RuntimeError:
+                    pass  # no EPSG authority code (e.g. ESRI:102003); proceed with WKT/PROJ definition
                 _epsg = _srs.GetAuthorityCode(None)
                 _crs_name = f"EPSG:{_epsg}" if _epsg else _srs.GetName() or "unknown projected CRS"
                 print(

--- a/cng_datasets/vector/convert_to_parquet.py
+++ b/cng_datasets/vector/convert_to_parquet.py
@@ -216,11 +216,8 @@ def download_and_extract(url: str, extract_to: str, verbose: bool = False) -> No
         local_zip = os.path.join(extract_to, "downloadpkg.zip")
 
         if url.startswith("s3://"):
-             # Simple S3 to https conversion for Nautilus
-             if "nrp-nautilus.io" in url or "public-iucn" in url: # minimal heuristic
-                 # This might need to be more robust, but complying with user request example
-                 path = url.replace("s3://", "")
-                 url = f"https://s3-west.nrp-nautilus.io/{path}"
+            path = url.replace("s3://", "")
+            url = f"https://s3-west.nrp-nautilus.io/{path}"
 
         if url.startswith(("http://", "https://")):
             urlretrieve(url, local_zip)
@@ -244,16 +241,26 @@ def download_and_extract(url: str, extract_to: str, verbose: bool = False) -> No
         raise RuntimeError(f"Failed to download/extract zip: {e}")
 
 
-def find_shapefiles(directory: str) -> List[str]:
+def find_vector_sources(directory: str) -> List[str]:
     """
-    Recursively find all .shp files in a directory.
+    Recursively find vector sources in a directory.
+    Returns .shp files if found; otherwise .gdb directories; otherwise .gpkg/.fgb files.
     """
     shapefiles = []
+    gdbs = []
+    others = []
     for root, dirs, files in os.walk(directory):
+        for d in list(dirs):
+            if d.lower().endswith(".gdb"):
+                gdbs.append(os.path.join(root, d))
+                dirs.remove(d)  # don't recurse into .gdb
         for file in files:
-            if file.lower().endswith(".shp"):
+            low = file.lower()
+            if low.endswith(".shp"):
                 shapefiles.append(os.path.join(root, file))
-    return sorted(shapefiles)
+            elif low.endswith((".gpkg", ".fgb")):
+                others.append(os.path.join(root, file))
+    return sorted(shapefiles) or sorted(gdbs) or sorted(others)
 
 
 def detect_crs(source_input: str, layer: Optional[str] = None, verbose: bool = False) -> Optional[str]:
@@ -903,15 +910,14 @@ def convert_to_parquet(
 
             download_and_extract(source_urls[0], temp_dir, verbose=verbose)
 
-            shapefiles = find_shapefiles(temp_dir)
-            if not shapefiles:
-                raise ValueError("No shapefiles found in zip archive")
+            source_inputs = find_vector_sources(temp_dir)
+            if not source_inputs:
+                raise ValueError("No vector sources (.shp, .gdb, .gpkg, .fgb) found in zip archive")
 
-            print(f"  Found {len(shapefiles)} shapefiles in archive")
-            source_inputs = shapefiles
+            print(f"  Found {len(source_inputs)} vector source(s) in archive")
 
-            # Use the first shapefile as representative for metadata
-            representative_source = shapefiles[0]
+            # Use the first source as representative for metadata
+            representative_source = source_inputs[0]
             print(f"  Using {os.path.basename(representative_source)} for metadata detection")
 
         elif is_multi_source:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,11 +13,7 @@ authors = [
     {name = "Boettiger Lab", email = "cboettig@berkeley.edu"}
 ]
 dependencies = [
-    # Cap below 1.5.4: the `h3` community extension (installed fresh in the
-    # Dockerfile) is not yet published for 1.5.4, so `INSTALL h3 FROM community`
-    # 404s and breaks the image build. 1.5.3 is the tested standard. Raise the
-    # ceiling once the h3 community build catches up to the newer release.
-    "duckdb>=0.10.0,<1.5.4",
+    "duckdb==1.5.4",
     "ibis-framework[duckdb]>=9.0.0",
     "polars>=0.20.0",
     "pyarrow>=15.0.0",

--- a/tests/test_convert_to_parquet.py
+++ b/tests/test_convert_to_parquet.py
@@ -5,12 +5,15 @@ import pytest
 import tempfile
 import os
 from pathlib import Path
+from unittest.mock import patch
 import duckdb
 from cng_datasets.vector.convert_to_parquet import (
     convert_to_parquet,
     build_read_reproject_query,
     write_with_duckdb,
     DEFAULT_ROW_GROUP_BYTES,
+    find_vector_sources,
+    download_and_extract,
 )
 
 
@@ -1333,3 +1336,82 @@ class TestRowGroupByteCap:
 
             assert total == 8000, f"expected all 8000 rows, got {total}"
             assert distinct == 8000, f"_cng_fid must stay row-unique, got {distinct} distinct"
+
+
+class TestFindVectorSources:
+    """find_vector_sources discovers .shp, .gdb dirs, and .gpkg/.fgb files (#130)."""
+
+    def test_finds_shapefiles(self):
+        with tempfile.TemporaryDirectory() as d:
+            shp = os.path.join(d, "data.shp")
+            open(shp, "w").close()
+            assert find_vector_sources(d) == [shp]
+
+    def test_finds_gdb_directory(self):
+        with tempfile.TemporaryDirectory() as d:
+            gdb = os.path.join(d, "data.gdb")
+            os.makedirs(gdb)
+            # place a file inside to confirm we don't recurse into .gdb
+            open(os.path.join(gdb, "inner.shp"), "w").close()
+            result = find_vector_sources(d)
+            assert result == [gdb], "should return .gdb dir, not files inside it"
+
+    def test_finds_gpkg_when_no_shp_or_gdb(self):
+        with tempfile.TemporaryDirectory() as d:
+            gpkg = os.path.join(d, "data.gpkg")
+            open(gpkg, "w").close()
+            assert find_vector_sources(d) == [gpkg]
+
+    def test_shp_takes_priority_over_gdb(self):
+        with tempfile.TemporaryDirectory() as d:
+            shp = os.path.join(d, "data.shp")
+            gdb = os.path.join(d, "data.gdb")
+            open(shp, "w").close()
+            os.makedirs(gdb)
+            result = find_vector_sources(d)
+            assert result == [shp]
+
+    def test_empty_directory_returns_empty(self):
+        with tempfile.TemporaryDirectory() as d:
+            assert find_vector_sources(d) == []
+
+
+class TestDownloadAndExtractS3Rewrite:
+    """Any s3:// URL is rewritten to the public https endpoint (#130)."""
+
+    def test_arbitrary_bucket_is_rewritten(self):
+        """s3://public-ca30x30/raw/ds2788.zip must reach urlretrieve as https."""
+        with tempfile.TemporaryDirectory() as d:
+            # Provide a real zip so extraction doesn't fail
+            import zipfile, io
+            buf = io.BytesIO()
+            with zipfile.ZipFile(buf, "w") as zf:
+                zf.writestr("placeholder.txt", "x")
+            zip_bytes = buf.getvalue()
+
+            def fake_retrieve(url, dest):
+                assert url == "https://s3-west.nrp-nautilus.io/public-ca30x30/raw/ds2788.zip", (
+                    f"unexpected URL: {url}"
+                )
+                with open(dest, "wb") as f:
+                    f.write(zip_bytes)
+
+            with patch("cng_datasets.vector.convert_to_parquet.urlretrieve", fake_retrieve):
+                download_and_extract("s3://public-ca30x30/raw/ds2788.zip", d)
+
+    def test_nrp_bucket_still_works(self):
+        """s3://nrp-nautilus.io/... (original case) also rewrites correctly."""
+        with tempfile.TemporaryDirectory() as d:
+            import zipfile, io
+            buf = io.BytesIO()
+            with zipfile.ZipFile(buf, "w") as zf:
+                zf.writestr("placeholder.txt", "x")
+            zip_bytes = buf.getvalue()
+
+            def fake_retrieve(url, dest):
+                assert url.startswith("https://s3-west.nrp-nautilus.io/"), f"unexpected URL: {url}"
+                with open(dest, "wb") as f:
+                    f.write(zip_bytes)
+
+            with patch("cng_datasets.vector.convert_to_parquet.urlretrieve", fake_retrieve):
+                download_and_extract("s3://nrp-nautilus.io/some/path.zip", d)

--- a/tests/test_raster.py
+++ b/tests/test_raster.py
@@ -157,6 +157,34 @@ class TestRasterProcessor:
         ds = None
         return raster_path
 
+    @pytest.fixture
+    def esri102003_raster(self, temp_dir):
+        """Raster with ESRI:102003 (USA Contiguous Albers) — no EPSG authority code (#131)."""
+        from osgeo import gdal, osr
+        width, height = 10, 10
+        raster_path = os.path.join(temp_dir, "esri102003.tif")
+        driver = gdal.GetDriverByName("GTiff")
+        ds = driver.Create(raster_path, width, height, 1, gdal.GDT_Float32)
+        ds.SetGeoTransform([-2000000, 10000, 0, 1000000, 0, -10000])
+        srs = osr.SpatialReference()
+        srs.ImportFromProj4(
+            "+proj=aea +lat_0=37.5 +lon_0=-96 +lat_1=29.5 +lat_2=45.5 "
+            "+x_0=0 +y_0=0 +datum=NAD83 +units=m +no_defs"
+        )
+        ds.SetProjection(srs.ExportToWkt())
+        ds.GetRasterBand(1).WriteArray(np.ones((height, width), dtype=np.float32))
+        ds.GetRasterBand(1).FlushCache()
+        ds = None
+        return raster_path
+
+    @pytest.mark.timeout(30)
+    def test_raster_processor_init_no_epsg_srs(self, esri102003_raster):
+        """RasterProcessor.__init__ must not crash on a raster with no EPSG authority code (#131)."""
+        from cng_datasets.raster.cog import RasterProcessor
+        # Should not raise RuntimeError from AutoIdentifyEPSG
+        proc = RasterProcessor(esri102003_raster, local_cache_dir=None)
+        assert proc.input_path is not None
+
     @pytest.mark.timeout(30)
     def test_detect_nodata_value(self, small_raster):
         """Test NoData value detection from raster metadata."""


### PR DESCRIPTION
## Summary

- **#134** — `pyproject.toml`: bump `duckdb` to `==1.5.4`; h3 community extension now ships for 1.5.4, stale cap and comment removed
- **#130** — `convert_to_parquet.py`:
  - `download_and_extract`: remove `nrp-nautilus.io`/`public-iucn` hostname guard; all `s3://` URLs now rewrite to the public https endpoint unconditionally
  - `find_shapefiles` → `find_vector_sources`: falls back to `.gdb` directories (without descending into them) and `.gpkg`/`.fgb` files when no `.shp` is found; error message updated
- **#131** — `cog.py`: wrap both `AutoIdentifyEPSG()` calls in `try/except RuntimeError` so rasters with no EPSG authority code (ESRI:102003, sphere Web-Mercator) no longer crash before reprojection

## Test plan

- [ ] Rebuild image with `--no-cache`; confirm `INSTALL h3 FROM community` succeeds and `SELECT h3_cell_to_latlng(...)` returns a result (#134)
- [ ] Run `cng-convert-to-parquet s3://public-ca30x30/raw/ds2788.zip s3://...` — should rewrite URL and extract GDB cleanly (#130)
- [ ] Run `cng-datasets raster --input climateConnectivityOmniscapeCalifornia.tif ...` (ESRI:102003 CRS) — should warn about projected CRS and proceed rather than crash (#131)