### PR TITLE
fix(#133): bound PMTiles max zoom; drop --extend-zooms-if-still-dropping

### DIFF
--- a/cng_datasets/k8s/workflows.py
+++ b/cng_datasets/k8s/workflows.py
@@ -458,6 +458,7 @@ def generate_dataset_workflow(
     max_completions: int = 200,
     intermediate_chunk_size: int = 10,
     row_group_size: int = 100000,
+    pmtiles_max_zoom: Optional[int] = None,
     backend: str = "k8s",
     hex_storage: str = "10Gi",
     repartition_storage: str = "50Gi",
@@ -563,7 +564,7 @@ def generate_dataset_workflow(
     _generate_convert_job(manager, k8s_name, source_urls, bucket, output_path, git_repo, layer, memory=hex_memory, row_group_size=row_group_size, s3_dataset=dataset_name, config=config)
 
     # Generate pmtiles job (uses converted parquet, not source)
-    _generate_pmtiles_job(manager, k8s_name, None, bucket, output_path, git_repo, memory=hex_memory, s3_dataset=dataset_name, config=config)
+    _generate_pmtiles_job(manager, k8s_name, None, bucket, output_path, git_repo, memory=hex_memory, s3_dataset=dataset_name, config=config, h3_resolution=h3_resolution, max_zoom=pmtiles_max_zoom)
 
     # Count features in source file(s) and calculate chunking parameters
     if len(source_urls) > 1:
@@ -1260,7 +1261,16 @@ cng-convert-to-parquet \\
     manager.save_job_yaml(job_spec, str(output_path / f"{dataset_name}-convert.yaml"))
 
 
-def _generate_pmtiles_job(manager, dataset_name, source_url, bucket, output_path, git_repo, memory="8Gi", s3_dataset=None, config: ClusterConfig = None):
+def _pmtiles_max_zoom(h3_resolution: Optional[int], max_zoom: Optional[int]) -> int:
+    """Derive PMTiles max zoom. Explicit max_zoom wins; otherwise res+3 (res-10→z13)."""
+    if max_zoom is not None:
+        return max_zoom
+    if h3_resolution is not None:
+        return h3_resolution + 3
+    return 13  # default matches res-10
+
+
+def _generate_pmtiles_job(manager, dataset_name, source_url, bucket, output_path, git_repo, memory="8Gi", s3_dataset=None, config: ClusterConfig = None, h3_resolution: Optional[int] = None, max_zoom: Optional[int] = None):
     """Generate PMTiles job.
 
     Uses the optimized GeoParquet from convert job as input (includes ID column).
@@ -1307,7 +1317,7 @@ ogr2ogr -wrapdateline -datelineoffset 15 -f GeoJSONSeq /tmp/$DATASET.geojsonl /v
 # environment, not the shell. A plain assignment is invisible to it, so it
 # falls back to the raw (non-power-of-2) CPU count and crashes (issue #77).
 export TIPPECANOE_MAX_THREADS=$(python3 -c "import os; n=os.cpu_count() or 1; print(1<<(n.bit_length()-1))")
-tippecanoe -o /tmp/$DATASET.pmtiles -l $DATASET --drop-densest-as-needed --extend-zooms-if-still-dropping --force /tmp/$DATASET.geojsonl
+tippecanoe -o /tmp/$DATASET.pmtiles -l $DATASET --coalesce-densest-as-needed --drop-densest-as-needed -z {_pmtiles_max_zoom(h3_resolution, max_zoom)} --force /tmp/$DATASET.geojsonl
 
 # Upload to S3 using rclone
 rclone copy /tmp/$DATASET.pmtiles {config.rclone_remote}:{bucket}/{s3_parent_dir}

--- a/cng_datasets/raster/cog.py
+++ b/cng_datasets/raster/cog.py
@@ -671,7 +671,10 @@ def create_mosaic_cog(
             print(f"  ⚠ Could not open {vsi_url}, skipping")
             continue
         srs = osr.SpatialReference(wkt=ds.GetProjection())
-        srs.AutoIdentifyEPSG()
+        try:
+            srs.AutoIdentifyEPSG()
+        except RuntimeError:
+            pass  # no EPSG authority code (e.g. ESRI:102003); proceed with WKT/PROJ definition
         epsg = srs.GetAuthorityCode(None)
         crs_key = f"EPSG:{epsg}" if epsg else srs.ExportToProj4()
         ds = None
@@ -920,7 +923,10 @@ class RasterProcessor:
             _srs = osr.SpatialReference(wkt=_ds.GetProjection())
             _ds = None
             if not _srs.IsGeographic():
-                _srs.AutoIdentifyEPSG()
+                try:
+                    _srs.AutoIdentifyEPSG()
+                except RuntimeError:
+                    pass  # no EPSG authority code (e.g. ESRI:102003); proceed with WKT/PROJ definition
                 _epsg = _srs.GetAuthorityCode(None)
                 _crs_name = f"EPSG:{_epsg}" if _epsg else _srs.GetName() or "unknown projected CRS"
                 print(

--- a/cng_datasets/vector/convert_to_parquet.py
+++ b/cng_datasets/vector/convert_to_parquet.py
@@ -468,10 +468,10 @@ def build_read_reproject_query(source_inputs: Union[str, List[str]], source_crs:
         # axis-order edge cases — geographic CRSs that are longitude-first (OGC:CRS84)
         # and geographic compound/3D CRSs with codes >= 5000 (EPSG:5498
         # "NAD83 + NAVD88 height", EPSG:4979) — swapping lat/lon for them (see #128).
-        geom_expr = f"ST_Transform({raw_geom}, '{source_crs}', '{target_crs}', always_xy := true) AS {geom_col}"
+        geom_expr = f"ST_MakeValid(ST_Transform({raw_geom}, '{source_crs}', '{target_crs}', always_xy := true)) AS {geom_col}"
     else:
         # No reprojection needed; DuckDB ST_Read returns (lon, lat) for all formats
-        geom_expr = f"{raw_geom} AS {geom_col}" if geom_is_blob else geom_col
+        geom_expr = f"ST_MakeValid({raw_geom}) AS {geom_col}"
 
     layer_param = f", layer='{layer}'" if layer else ""
 

--- a/cng_datasets/vector/convert_to_parquet.py
+++ b/cng_datasets/vector/convert_to_parquet.py
@@ -216,11 +216,8 @@ def download_and_extract(url: str, extract_to: str, verbose: bool = False) -> No
         local_zip = os.path.join(extract_to, "downloadpkg.zip")
 
         if url.startswith("s3://"):
-             # Simple S3 to https conversion for Nautilus
-             if "nrp-nautilus.io" in url or "public-iucn" in url: # minimal heuristic
-                 # This might need to be more robust, but complying with user request example
-                 path = url.replace("s3://", "")
-                 url = f"https://s3-west.nrp-nautilus.io/{path}"
+            path = url.replace("s3://", "")
+            url = f"https://s3-west.nrp-nautilus.io/{path}"
 
         if url.startswith(("http://", "https://")):
             urlretrieve(url, local_zip)
@@ -244,16 +241,26 @@ def download_and_extract(url: str, extract_to: str, verbose: bool = False) -> No
         raise RuntimeError(f"Failed to download/extract zip: {e}")
 
 
-def find_shapefiles(directory: str) -> List[str]:
+def find_vector_sources(directory: str) -> List[str]:
     """
-    Recursively find all .shp files in a directory.
+    Recursively find vector sources in a directory.
+    Returns .shp files if found; otherwise .gdb directories; otherwise .gpkg/.fgb files.
     """
     shapefiles = []
+    gdbs = []
+    others = []
     for root, dirs, files in os.walk(directory):
+        for d in list(dirs):
+            if d.lower().endswith(".gdb"):
+                gdbs.append(os.path.join(root, d))
+                dirs.remove(d)  # don't recurse into .gdb
         for file in files:
-            if file.lower().endswith(".shp"):
+            low = file.lower()
+            if low.endswith(".shp"):
                 shapefiles.append(os.path.join(root, file))
-    return sorted(shapefiles)
+            elif low.endswith((".gpkg", ".fgb")):
+                others.append(os.path.join(root, file))
+    return sorted(shapefiles) or sorted(gdbs) or sorted(others)
 
 
 def detect_crs(source_input: str, layer: Optional[str] = None, verbose: bool = False) -> Optional[str]:
@@ -903,15 +910,14 @@ def convert_to_parquet(
 
             download_and_extract(source_urls[0], temp_dir, verbose=verbose)
 
-            shapefiles = find_shapefiles(temp_dir)
-            if not shapefiles:
-                raise ValueError("No shapefiles found in zip archive")
+            source_inputs = find_vector_sources(temp_dir)
+            if not source_inputs:
+                raise ValueError("No vector sources (.shp, .gdb, .gpkg, .fgb) found in zip archive")
 
-            print(f"  Found {len(shapefiles)} shapefiles in archive")
-            source_inputs = shapefiles
+            print(f"  Found {len(source_inputs)} vector source(s) in archive")
 
-            # Use the first shapefile as representative for metadata
-            representative_source = shapefiles[0]
+            # Use the first source as representative for metadata
+            representative_source = source_inputs[0]
             print(f"  Using {os.path.basename(representative_source)} for metadata detection")
 
         elif is_multi_source:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,11 +13,7 @@ authors = [
     {name = "Boettiger Lab", email = "cboettig@berkeley.edu"}
 ]
 dependencies = [
-    # Cap below 1.5.4: the `h3` community extension (installed fresh in the
-    # Dockerfile) is not yet published for 1.5.4, so `INSTALL h3 FROM community`
-    # 404s and breaks the image build. 1.5.3 is the tested standard. Raise the
-    # ceiling once the h3 community build catches up to the newer release.
-    "duckdb>=0.10.0,<1.5.4",
+    "duckdb==1.5.4",
     "ibis-framework[duckdb]>=9.0.0",
     "polars>=0.20.0",
     "pyarrow>=15.0.0",

--- a/tests/test_convert_to_parquet.py
+++ b/tests/test_convert_to_parquet.py
@@ -50,6 +50,20 @@ class TestReprojectQueryAxisOrder:
         )
         assert "ST_Transform" not in sql
 
+    def test_make_valid_always_present(self):
+        """ST_MakeValid must wrap the geometry expression in every code path (#122)."""
+        for source_crs, target_crs in [
+            ("EPSG:3310", "EPSG:4326"),   # reprojection path
+            ("EPSG:4326", "EPSG:4326"),   # no-reprojection path
+            (None, "EPSG:4326"),          # no source CRS
+        ]:
+            sql = build_read_reproject_query(
+                "dummy.gpkg", source_crs=source_crs, target_crs=target_crs, geom_col="geom"
+            )
+            assert "ST_MakeValid" in sql, (
+                f"ST_MakeValid missing from query for source_crs={source_crs!r}"
+            )
+
     def test_compound_crs_transform_preserves_lon_lat(self):
         """End-to-end ST_Transform check (no ogr2ogr needed): a point stored as
         (lon, lat) in EPSG:5498 must remain (lon, lat) after transform to EPSG:4326.

--- a/tests/test_convert_to_parquet.py
+++ b/tests/test_convert_to_parquet.py
@@ -5,12 +5,15 @@ import pytest
 import tempfile
 import os
 from pathlib import Path
+from unittest.mock import patch
 import duckdb
 from cng_datasets.vector.convert_to_parquet import (
     convert_to_parquet,
     build_read_reproject_query,
     write_with_duckdb,
     DEFAULT_ROW_GROUP_BYTES,
+    find_vector_sources,
+    download_and_extract,
 )
 
 
@@ -1333,3 +1336,82 @@ class TestRowGroupByteCap:
 
             assert total == 8000, f"expected all 8000 rows, got {total}"
             assert distinct == 8000, f"_cng_fid must stay row-unique, got {distinct} distinct"
+
+
+class TestFindVectorSources:
+    """find_vector_sources discovers .shp, .gdb dirs, and .gpkg/.fgb files (#130)."""
+
+    def test_finds_shapefiles(self):
+        with tempfile.TemporaryDirectory() as d:
+            shp = os.path.join(d, "data.shp")
+            open(shp, "w").close()
+            assert find_vector_sources(d) == [shp]
+
+    def test_finds_gdb_directory(self):
+        with tempfile.TemporaryDirectory() as d:
+            gdb = os.path.join(d, "data.gdb")
+            os.makedirs(gdb)
+            # place a file inside to confirm we don't recurse into .gdb
+            open(os.path.join(gdb, "inner.shp"), "w").close()
+            result = find_vector_sources(d)
+            assert result == [gdb], "should return .gdb dir, not files inside it"
+
+    def test_finds_gpkg_when_no_shp_or_gdb(self):
+        with tempfile.TemporaryDirectory() as d:
+            gpkg = os.path.join(d, "data.gpkg")
+            open(gpkg, "w").close()
+            assert find_vector_sources(d) == [gpkg]
+
+    def test_shp_takes_priority_over_gdb(self):
+        with tempfile.TemporaryDirectory() as d:
+            shp = os.path.join(d, "data.shp")
+            gdb = os.path.join(d, "data.gdb")
+            open(shp, "w").close()
+            os.makedirs(gdb)
+            result = find_vector_sources(d)
+            assert result == [shp]
+
+    def test_empty_directory_returns_empty(self):
+        with tempfile.TemporaryDirectory() as d:
+            assert find_vector_sources(d) == []
+
+
+class TestDownloadAndExtractS3Rewrite:
+    """Any s3:// URL is rewritten to the public https endpoint (#130)."""
+
+    def test_arbitrary_bucket_is_rewritten(self):
+        """s3://public-ca30x30/raw/ds2788.zip must reach urlretrieve as https."""
+        with tempfile.TemporaryDirectory() as d:
+            # Provide a real zip so extraction doesn't fail
+            import zipfile, io
+            buf = io.BytesIO()
+            with zipfile.ZipFile(buf, "w") as zf:
+                zf.writestr("placeholder.txt", "x")
+            zip_bytes = buf.getvalue()
+
+            def fake_retrieve(url, dest):
+                assert url == "https://s3-west.nrp-nautilus.io/public-ca30x30/raw/ds2788.zip", (
+                    f"unexpected URL: {url}"
+                )
+                with open(dest, "wb") as f:
+                    f.write(zip_bytes)
+
+            with patch("cng_datasets.vector.convert_to_parquet.urlretrieve", fake_retrieve):
+                download_and_extract("s3://public-ca30x30/raw/ds2788.zip", d)
+
+    def test_nrp_bucket_still_works(self):
+        """s3://nrp-nautilus.io/... (original case) also rewrites correctly."""
+        with tempfile.TemporaryDirectory() as d:
+            import zipfile, io
+            buf = io.BytesIO()
+            with zipfile.ZipFile(buf, "w") as zf:
+                zf.writestr("placeholder.txt", "x")
+            zip_bytes = buf.getvalue()
+
+            def fake_retrieve(url, dest):
+                assert url.startswith("https://s3-west.nrp-nautilus.io/"), f"unexpected URL: {url}"
+                with open(dest, "wb") as f:
+                    f.write(zip_bytes)
+
+            with patch("cng_datasets.vector.convert_to_parquet.urlretrieve", fake_retrieve):
+                download_and_extract("s3://nrp-nautilus.io/some/path.zip", d)

--- a/tests/test_k8s_workflows.py
+++ b/tests/test_k8s_workflows.py
@@ -277,6 +277,53 @@ class TestWorkflowGeneration:
             assert "export TIPPECANOE_MAX_THREADS=" in command
 
     @pytest.mark.timeout(5)
+    def test_pmtiles_max_zoom_derived_from_h3_resolution(self):
+        """PMTiles max zoom defaults to h3_resolution+3; --extend-zooms removed (#133)."""
+        from cng_datasets.k8s.workflows import _pmtiles_max_zoom
+        assert _pmtiles_max_zoom(10, None) == 13
+        assert _pmtiles_max_zoom(9, None) == 12
+        assert _pmtiles_max_zoom(8, None) == 11
+        assert _pmtiles_max_zoom(None, None) == 13   # fallback default
+        assert _pmtiles_max_zoom(10, 16) == 16       # explicit override wins
+
+    @pytest.mark.timeout(5)
+    def test_pmtiles_job_no_extend_zooms(self):
+        """tippecanoe command must not contain --extend-zooms-if-still-dropping (#133)."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            generate_dataset_workflow(
+                dataset_name="test-ds",
+                source_url="https://s3-west.nrp-nautilus.io/public-test/fixtures/test-fixture.gpkg",
+                bucket="test-bucket",
+                output_dir=tmpdir,
+                h3_resolution=10,
+            )
+            pmtiles_file = Path(tmpdir) / "test-ds-pmtiles.yaml"
+            with open(pmtiles_file) as f:
+                job = yaml.safe_load(f)
+            command = job["spec"]["template"]["spec"]["containers"][0]["command"][2]
+            assert "--extend-zooms-if-still-dropping" not in command
+            assert "-z 13" in command
+            assert "--coalesce-densest-as-needed" in command
+
+    @pytest.mark.timeout(5)
+    def test_pmtiles_max_zoom_override(self):
+        """pmtiles_max_zoom kwarg overrides the H3-derived default (#133)."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            generate_dataset_workflow(
+                dataset_name="test-ds",
+                source_url="https://s3-west.nrp-nautilus.io/public-test/fixtures/test-fixture.gpkg",
+                bucket="test-bucket",
+                output_dir=tmpdir,
+                h3_resolution=10,
+                pmtiles_max_zoom=16,
+            )
+            pmtiles_file = Path(tmpdir) / "test-ds-pmtiles.yaml"
+            with open(pmtiles_file) as f:
+                job = yaml.safe_load(f)
+            command = job["spec"]["template"]["spec"]["containers"][0]["command"][2]
+            assert "-z 16" in command
+
+    @pytest.mark.timeout(5)
     def test_workflow_rbac(self):
         """Test RBAC configuration is generated."""
         with tempfile.TemporaryDirectory() as tmpdir:

--- a/tests/test_raster.py
+++ b/tests/test_raster.py
@@ -157,6 +157,34 @@ class TestRasterProcessor:
         ds = None
         return raster_path
 
+    @pytest.fixture
+    def esri102003_raster(self, temp_dir):
+        """Raster with ESRI:102003 (USA Contiguous Albers) — no EPSG authority code (#131)."""
+        from osgeo import gdal, osr
+        width, height = 10, 10
+        raster_path = os.path.join(temp_dir, "esri102003.tif")
+        driver = gdal.GetDriverByName("GTiff")
+        ds = driver.Create(raster_path, width, height, 1, gdal.GDT_Float32)
+        ds.SetGeoTransform([-2000000, 10000, 0, 1000000, 0, -10000])
+        srs = osr.SpatialReference()
+        srs.ImportFromProj4(
+            "+proj=aea +lat_0=37.5 +lon_0=-96 +lat_1=29.5 +lat_2=45.5 "
+            "+x_0=0 +y_0=0 +datum=NAD83 +units=m +no_defs"
+        )
+        ds.SetProjection(srs.ExportToWkt())
+        ds.GetRasterBand(1).WriteArray(np.ones((height, width), dtype=np.float32))
+        ds.GetRasterBand(1).FlushCache()
+        ds = None
+        return raster_path
+
+    @pytest.mark.timeout(30)
+    def test_raster_processor_init_no_epsg_srs(self, esri102003_raster):
+        """RasterProcessor.__init__ must not crash on a raster with no EPSG authority code (#131)."""
+        from cng_datasets.raster.cog import RasterProcessor
+        # Should not raise RuntimeError from AutoIdentifyEPSG
+        proc = RasterProcessor(esri102003_raster, local_cache_dir=None)
+        assert proc.input_path is not None
+
     @pytest.mark.timeout(30)
     def test_detect_nodata_value(self, small_raster):
         """Test NoData value detection from raster metadata."""


### PR DESCRIPTION
## Summary

- Removes `--extend-zooms-if-still-dropping` from the tippecanoe command — this flag never converges on dense national datasets (e.g. FEMA NFHL ran 4h+ stuck at 99.9%, producing nothing)
- Adds `-z <max_zoom>` derived from H3 resolution using `res + 3` (res-10 → z13, res-9 → z12, res-8 → z11 etc.), which matches the analysis grid and is finer than the simplification tolerance
- Adds `--coalesce-densest-as-needed` to bound per-tile size at each zoom without dropping features at a given level
- Adds `pmtiles_max_zoom` kwarg to `generate_dataset_workflow` for datasets that legitimately want higher zoom (e.g. parcel-level, z16)
- `_pmtiles_max_zoom()` helper: explicit override > res+3 > 13 fallback

## Test plan

- [ ] CI passes
- [ ] Re-run FEMA NFHL flood zones (data-workflows #253, 5.6M polygons) — should complete in minutes at z13 instead of thrashing past z14
- [ ] Verify tiles render correctly in the GeoAgent map viewer up to z13