### PR TITLE
feat(#142): fractional-coverage reducer for categorical H3 hex

### DIFF
--- a/cng_datasets/cli.py
+++ b/cng_datasets/cli.py
@@ -58,10 +58,12 @@ def main():
     raster_parser.add_argument("--hex-resampling", default="mean",
                                help="Reducer for aggregating source pixels into each "
                                     "H3 cell. With --method=exact-extract (default), "
-                                    "one of: sum/mean/mode/max/min (max/min for "
-                                    "peak/richness rasters). With --method=warp-centroid, "
-                                    "any GDAL resampleAlg (average, sum, mode, near, "
-                                    "bilinear, cubic, ...). Default: mean.")
+                                    "one of: sum/mean/mode/fractions/max/min (max/min for "
+                                    "peak/richness rasters; 'fractions' emits per-class "
+                                    "coverage rows for categorical area accounting, #142). "
+                                    "With --method=warp-centroid, any GDAL resampleAlg "
+                                    "(average, sum, mode, near, bilinear, cubic, ...). "
+                                    "Default: mean.")
     raster_parser.add_argument("--method", default="exact-extract",
                                choices=("exact-extract", "warp-centroid"),
                                help="Raster→hex algorithm. 'exact-extract' (default): "
@@ -154,8 +156,10 @@ def main():
                                         choices=VALID_HEX_REDUCERS,
                                         help="Reducer for H3 aggregation. 'sum' for "
                                              "counts (population, carbon); 'mean' for intensities; "
-                                             "'mode' for categorical; 'max'/'min' for peak/extremum "
-                                             "(species richness). Default: mean.")
+                                             "'mode' for categorical (single dominant class); "
+                                             "'fractions' for categorical area accounting (one "
+                                             "(value, frac) row per class per cell); 'max'/'min' "
+                                             "for peak/extremum (species richness). Default: mean.")
     raster_workflow_parser.add_argument("--hex-memory", type=str, default="32Gi", help="Memory per hex job pod (default: 32Gi)")
     raster_workflow_parser.add_argument("--max-parallelism", type=int, default=61, help="Maximum parallel hex jobs (default: 61)")
     raster_workflow_parser.add_argument("--hex-storage", type=str, default="20Gi", help="Ephemeral storage request/limit per hex job pod (default: 20Gi)")
@@ -257,9 +261,11 @@ def _dispatch(args):
 
         # If multiple inputs and only --output-cog requested, use create_mosaic_cog directly
         if isinstance(input_path, list) and args.output_cog and not args.output_parquet:
-            # Categorical sources (--hex-resampling mode) must not average class
-            # codes in the COG overviews (issue #108).
-            overview_resampling = "mode" if args.hex_resampling == "mode" else "average"
+            # Categorical sources (--hex-resampling mode/fractions) must not
+            # average class codes in the COG overviews (issue #108).
+            overview_resampling = (
+                "mode" if args.hex_resampling in ("mode", "fractions") else "average"
+            )
             create_mosaic_cog(
                 source_urls=input_path,
                 output_path=args.output_cog,

--- a/cng_datasets/k8s/workflows.py
+++ b/cng_datasets/k8s/workflows.py
@@ -727,6 +727,8 @@ def generate_raster_workflow(
             Use "sum" for counts/stocks (population, carbon), "mean" for
             intensities (NDVI, indices), "mode" for categorical (land cover) to
             preserve class codes — averaging yields meaningless non-canonical values.
+            Use "fractions" for categorical area accounting: per-class coverage
+            rows (value, frac) per cell so areas are exact, not mode-biased (#142).
         hex_memory: Memory per hex pod (default: "32Gi")
         max_parallelism: Max parallel hex pods (default: 61)
         target_extent: Clip bbox (xmin, ymin, xmax, ymax) in EPSG:4326 for mosaic step

--- a/cng_datasets/raster/cog.py
+++ b/cng_datasets/raster/cog.py
@@ -73,6 +73,39 @@ def _split_antimeridian(geom):
         return valid if not valid.is_empty else geom
 
 
+def _explode_fractions(df):
+    """Explode exactextract's per-cell unique/frac arrays into long rows.
+
+    `ops=["unique", "frac"]` returns one row per cell with two parallel
+    object-arrays: the distinct values present and each one's coverage-weighted
+    share of the cell. The H3 partitioned-join model wants one row per
+    (cell, class), so expand to a flat (_h3_str, value, frac) frame. Uses
+    np.repeat/concatenate rather than DataFrame.explode — a chunk can be 100k
+    cells x several classes, and the vectorized path is markedly cheaper.
+    Cells with no covered pixels (entirely outside the raster footprint) carry
+    empty arrays and contribute no rows.
+    """
+    import numpy as np
+    import pandas as pd
+
+    uniq = df["unique"].to_list()
+    frac = df["frac"].to_list()
+    h3 = df["_h3_str"].to_numpy()
+    counts = np.fromiter(
+        (0 if u is None else len(u) for u in uniq), dtype="int64", count=len(uniq)
+    )
+    if int(counts.sum()) == 0:
+        return pd.DataFrame(
+            {"_h3_str": h3[:0], "value": np.array([], dtype="float64"),
+             "frac": np.array([], dtype="float64")}
+        )
+    vals = np.concatenate([u for u in uniq if u is not None and len(u)])
+    frs = np.concatenate([f for f in frac if f is not None and len(f)])
+    return pd.DataFrame(
+        {"_h3_str": np.repeat(h3, counts), "value": vals, "frac": frs}
+    )
+
+
 def _exact_extract_chunk(args):
     """Worker for chunked-parallel exact_extract over one slice of cells.
 
@@ -81,6 +114,11 @@ def _exact_extract_chunk(args):
     pixel cache), receives a primitive list of (h3_id, boundary_wkt) pairs,
     and returns a pandas DataFrame with the op output plus the cell id
     column as a string (the caller casts back to uint64).
+
+    For the "fractions" reducer (#142) the worker requests exactextract's
+    ["unique", "frac"] ops and returns the LONG (_h3_str, value, frac) shape;
+    every other reducer maps to a single exactextract op and returns one row
+    per cell.
 
     Retries transient TIFF/HTTP read failures up to a few times — Ceph S3
     occasionally returns truncated tile reads under heavy concurrent load,
@@ -95,6 +133,9 @@ def _exact_extract_chunk(args):
     raster_path, op_name, chunk_cells = args
     if not chunk_cells:
         return None
+
+    is_fractions = op_name == "fractions"
+    ops = ["unique", "frac"] if is_fractions else [op_name]
 
     # Split cells that straddle +/-180 into a MultiPolygon so exact_extract
     # integrates their true footprint, not a 360-deg ribbon (issue #88).
@@ -112,13 +153,21 @@ def _exact_extract_chunk(args):
     last_exc = None
     for attempt in range(max_attempts):
         try:
-            return exact_extract(
+            result = exact_extract(
                 rast=raster_path,
                 vec=gdf,
-                ops=[op_name],
+                ops=ops,
                 output="pandas",
                 include_cols=["_h3_str"],
             )
+            if not is_fractions:
+                return result
+            # exactextract column naming: bare "unique"/"frac" for single-band
+            # rasters, "band_1_unique"/… on older versions or multi-band.
+            ucol = [c for c in result.columns if c == "unique" or c.endswith("_unique")][0]
+            fcol = [c for c in result.columns if c == "frac" or c.endswith("_frac")][0]
+            result = result.rename(columns={ucol: "unique", fcol: "frac"})
+            return _explode_fractions(result)
         except RuntimeError as exc:
             msg = str(exc)
             msg_lower = msg.lower()
@@ -259,9 +308,17 @@ def _configure_proj():
 # coverage-weighted (#84); "mode" is the categorical majority; "max"/"min" are
 # coverage-agnostic extrema for peak/"max-over-area" rasters like species
 # richness, where sum double-counts and mean averages away the hotspot (#95).
+# "fractions" is the area-accounting reducer for categorical sources (#142):
+# instead of one dominant class per cell (lossy — minority classes inside a
+# mixed cell are absorbed by the mode), it emits one LONG row per present
+# class, (value, frac, h<res>), where frac is the class's coverage-weighted
+# share of the cell. Area of class X is then the cheap hex join
+# SUM(frac * cell_area). nodata is kept as an explicit class so frac sums to
+# <= 1 per cell and the nodata/unclassified share is recoverable rather than
+# silently inflating the real classes.
 # Used both for runtime validation in RasterProcessor.__init__ and as
 # argparse `choices=` in the CLI.
-VALID_HEX_REDUCERS = ("sum", "mean", "mode", "max", "min")
+VALID_HEX_REDUCERS = ("sum", "mean", "mode", "max", "min", "fractions")
 
 # Two implementations of the raster → H3 hex aggregation step.
 # - "exact-extract" (default): polyfill h0 → cells, exact_extract per-cell.
@@ -846,9 +903,13 @@ class RasterProcessor:
             hex_resampling: Reducer for aggregating source pixels into each
                 H3 cell. With method="exact-extract" (default), one of:
                 "sum" (counts/stocks like population), "mean" (intensities
-                like NDVI), "mode" (categorical like land cover), "max"/"min"
-                (peak/extremum like species richness, where sum double-counts
-                and mean averages away the hotspot). With
+                like NDVI), "mode" (categorical like land cover — single
+                dominant class per cell), "fractions" (categorical area
+                accounting — one LONG (value, frac) row per class present in
+                each cell, with nodata kept as an explicit class so frac sums
+                to <= 1 and area is SUM(frac * cell_area), issue #142),
+                "max"/"min" (peak/extremum like species richness, where sum
+                double-counts and mean averages away the hotspot). With
                 method="warp-centroid", any GDAL resampleAlg is accepted
                 ("average", "sum", "mode", "near", "bilinear", "cubic", ...).
                 Default: "mean".
@@ -1089,9 +1150,9 @@ class RasterProcessor:
             output_path: Path for output COG (uses self.output_cog_path if None)
             overviews: Whether to create overview pyramids
             overview_resampling: Resampling method for overviews. Defaults to
-                "mode" when hex_resampling is "mode" (categorical — averaging
-                class codes corrupts the zoomed-out COG, issue #108) and
-                "average" otherwise.
+                "mode" when hex_resampling is categorical ("mode"/"fractions" —
+                averaging class codes corrupts the zoomed-out COG, issue #108)
+                and "average" otherwise.
 
         Returns:
             Path to created COG file
@@ -1103,9 +1164,10 @@ class RasterProcessor:
             raise ValueError("output_path or output_cog_path must be specified")
 
         if overview_resampling is None:
-            # Categorical rasters (hex_resampling="mode") must not average their
-            # class codes in overviews — use mode (issue #108).
-            overview_resampling = "mode" if self.hex_resampling == "mode" else "average"
+            # Categorical rasters (hex_resampling "mode"/"fractions") must not
+            # average their class codes in overviews — use mode (issue #108).
+            categorical = self.hex_resampling in ("mode", "fractions")
+            overview_resampling = "mode" if categorical else "average"
 
         print(f"Creating COG: {output_path}")
         print(f"  Input: {self.input_path}")
@@ -1333,6 +1395,14 @@ class RasterProcessor:
         # band nodata, so they are physically remapped to the primary in a
         # collapsed copy built once and reused across h0 regions.
         nodata_values = self.nodata_values
+        is_fractions = self.hex_resampling == "fractions"
+        # For "fractions" the nodata code is KEPT as an explicit class (#142) so
+        # frac is the class's share of the cell *including* nodata, sums to <= 1,
+        # and the nodata/unclassified share is recoverable (rather than silently
+        # re-inflating the real classes the way valid-coverage normalization
+        # would). Cells with at least one nodata code that we still want labelled
+        # explicitly are filtered below; the codes that mark "nodata" downstream:
+        nodata_codes = [nodata_values[0]] if (is_fractions and nodata_values) else []
         with rasterio.open(self.input_path) as rast:
             src_nodata = rast.nodata
 
@@ -1340,6 +1410,18 @@ class RasterProcessor:
         try:
             if not nodata_values:
                 rast_arg = self.input_path
+            elif is_fractions:
+                # Collapse multi-fill to the primary first (#108), then CLEAR the
+                # band nodata so exactextract returns it as a normal class. The
+                # collapse step sets band nodata = primary, so a no-nodata VRT is
+                # built over whichever base we use.
+                base = (
+                    self._collapsed_aggregation_input()
+                    if len(nodata_values) > 1 else self.input_path
+                )
+                vrt_path = f"/tmp/raster_{h0_cell}_keepnodata.vrt"
+                gdal.Translate(vrt_path, base, format="VRT", noData="none")
+                rast_arg = vrt_path
             elif len(nodata_values) == 1:
                 if src_nodata != nodata_values[0]:
                     vrt_path = f"/tmp/raster_{h0_cell}_nodata.vrt"
@@ -1391,21 +1473,27 @@ class RasterProcessor:
         results[h3_col] = results["_h3_str"].astype("uint64")
         results = results.drop(columns=["_h3_str"])
 
-        # exactextract column naming: older versions emit "band_1_{op}",
-        # newer versions (>=0.3) emit just "{op}" for single-band rasters.
-        op_col = [
-            c for c in results.columns
-            if c == self.hex_resampling or c.endswith(f"_{self.hex_resampling}")
-        ]
-        if not op_col:
-            raise RuntimeError(
-                f"exactextract returned no '{self.hex_resampling}' column; "
-                f"got {list(results.columns)}"
-            )
-        results = results.rename(columns={op_col[0]: self.value_column})
+        if is_fractions:
+            # Worker already returned long (value, frac) rows; just rename the
+            # class column and drop any rows that carry no coverage fraction.
+            results = results.rename(columns={"value": self.value_column})
+            results = results[results["frac"].notna()]
+        else:
+            # exactextract column naming: older versions emit "band_1_{op}",
+            # newer versions (>=0.3) emit just "{op}" for single-band rasters.
+            op_col = [
+                c for c in results.columns
+                if c == self.hex_resampling or c.endswith(f"_{self.hex_resampling}")
+            ]
+            if not op_col:
+                raise RuntimeError(
+                    f"exactextract returned no '{self.hex_resampling}' column; "
+                    f"got {list(results.columns)}"
+                )
+            results = results.rename(columns={op_col[0]: self.value_column})
+            # Drop cells that produced no covered pixels (all-nodata under cell).
+            results = results[results[self.value_column].notna()]
 
-        # Drop cells that produced no covered pixels (all-nodata under the cell).
-        results = results[results[self.value_column].notna()]
         if len(results) == 0:
             print(f"  ℹ h0 {h0_cell}: no cells produced values (all nodata)")
             return None
@@ -1427,12 +1515,36 @@ class RasterProcessor:
         )
         os.makedirs(os.path.dirname(output_path), exist_ok=True)
 
-        self.con.execute(f"""
-            COPY (
-                SELECT {self.value_column}, {h3_col}{parent_sql}
-                FROM hex_values
-            ) TO '{output_path}' (FORMAT PARQUET, COMPRESSION 'zstd')
-        """)
+        if is_fractions:
+            # Keep nodata rows only for cells that also hold a real class, so the
+            # nodata fraction stays explicit on mixed/edge cells (#142) while
+            # cells that are *entirely* nodata (e.g. open ocean under a land
+            # raster) are dropped rather than emitting a nodata-only row per
+            # cell — which would balloon the partition over empty areas.
+            select_cols = f"{self.value_column}, frac, {h3_col}{parent_sql}"
+            where_sql = ""
+            if nodata_codes:
+                codes = ", ".join(_fmt_gdal(c) for c in nodata_codes)
+                where_sql = (
+                    f"WHERE {h3_col} IN ("
+                    f"SELECT {h3_col} FROM hex_values "
+                    f"WHERE {self.value_column} NOT IN ({codes}))"
+                )
+            copy_sql = f"""
+                COPY (
+                    SELECT {select_cols}
+                    FROM hex_values
+                    {where_sql}
+                ) TO '{output_path}' (FORMAT PARQUET, COMPRESSION 'zstd')
+            """
+        else:
+            copy_sql = f"""
+                COPY (
+                    SELECT {self.value_column}, {h3_col}{parent_sql}
+                    FROM hex_values
+                ) TO '{output_path}' (FORMAT PARQUET, COMPRESSION 'zstd')
+            """
+        self.con.execute(copy_sql)
         self.con.unregister("hex_values")
 
         # Fail fast if the h3 extension emitted signed BIGINT parents (issue #102):
@@ -1443,7 +1555,8 @@ class RasterProcessor:
             lambda sql: self.con.execute(sql).fetchall(), output_path
         )
 
-        print(f"  ✓ Wrote: {output_path} ({len(results)} cells)")
+        unit = "class rows" if is_fractions else "cells"
+        print(f"  ✓ Wrote: {output_path} ({len(results)} {unit})")
         return output_path
 
     def process_h0_region(self, h0_index: Optional[int] = None) -> Optional[str]:

--- a/tests/test_raster.py
+++ b/tests/test_raster.py
@@ -1431,7 +1431,7 @@ class TestMultiValueNodata:
         ds = None
         return raster_path
 
-    def _run_hex(self, raster, temp_dir, nodata_value):
+    def _run_hex(self, raster, temp_dir, nodata_value, hex_resampling="mode"):
         import geopandas as gpd
         from shapely.geometry import box
         from cng_datasets.raster import RasterProcessor
@@ -1453,12 +1453,60 @@ class TestMultiValueNodata:
             parent_resolutions=[0],
             h0_grid_path=h0_file,
             value_column="evt",
-            hex_resampling="mode",
+            hex_resampling=hex_resampling,
             nodata_value=nodata_value,
         )
         result = proc.process_h0_region(0)
         df = proc.con.read_parquet(result).fetchdf() if result else None
         return result, df
+
+    @pytest.mark.timeout(180)
+    def test_hex_fractions_emits_per_class_long_rows(self, categorical_raster, temp_dir):
+        """fractions reducer emits long (evt, frac) rows per class per cell (#142).
+
+        Every genuine class survives (no mode-style absorption of minority
+        classes), each carries a coverage fraction in (0, 1], and the fractions
+        within a cell sum to <= 1 (the cell extends past the tiny test raster,
+        so the remainder is unclassified/outside-raster).
+        """
+        result, df = self._run_hex(
+            categorical_raster, temp_dir, "-9999,-1111,32767",
+            hex_resampling="fractions",
+        )
+        assert result is not None
+        # Long schema: a class column, a coverage fraction, and the native cell.
+        assert "evt" in df.columns and "frac" in df.columns and "h5" in df.columns
+        # No mode collapse — all three genuine classes are present as rows.
+        for cls in (11, 22, 33):
+            assert cls in df["evt"].values, f"class {cls} missing from fractions output"
+        assert (df["frac"] > 0).all() and (df["frac"] <= 1.0 + 1e-9).all()
+        # Per-cell fractions never exceed the whole cell.
+        per_cell = df.groupby("h5")["frac"].sum()
+        assert (per_cell <= 1.0 + 1e-9).all()
+
+    @pytest.mark.timeout(180)
+    def test_hex_fractions_keeps_nodata_as_explicit_class(self, categorical_raster, temp_dir):
+        """nodata is carried as an explicit class so its share is recoverable
+        rather than silently inflating the real classes (#142).
+
+        The fill codes are collapsed to the primary (-9999) and kept; cells that
+        hold at least one real class therefore also carry a -9999 row.
+        """
+        result, df = self._run_hex(
+            categorical_raster, temp_dir, "-9999,-1111,32767",
+            hex_resampling="fractions",
+        )
+        assert result is not None
+        # The collapsed nodata code appears explicitly (the raster has fill px).
+        assert -9999 in df["evt"].values
+        # The other fill codes were collapsed away, not leaked as classes.
+        for leaked in (-1111, 32767):
+            assert leaked not in df["evt"].values
+        # Every cell that carries the nodata code also carries a real class
+        # (pure-nodata cells are dropped, not emitted as nodata-only rows).
+        nodata_cells = set(df.loc[df["evt"] == -9999, "h5"])
+        real_cells = set(df.loc[df["evt"].isin([11, 22, 33]), "h5"])
+        assert nodata_cells <= real_cells
 
     @pytest.mark.timeout(180)
     def test_hex_excludes_secondary_fill_code(self, secondary_fill_raster, temp_dir):
@@ -1486,6 +1534,92 @@ class TestMultiValueNodata:
         if result:
             for fill in (-9999, -1111, 32767):
                 assert fill not in df["evt"].values, f"fill code {fill} leaked into hex output"
+
+
+@requires_gdal
+class TestFractionsWorker:
+    """Fractions-reducer worker internals (#142).
+
+    Exercises the explode helper and the exact_extract chunk worker directly,
+    isolating the long-explode logic from the gdal.Translate nodata-clearing
+    path in _hex_aggregate_h0. The aggregation logic itself needs only
+    numpy/pandas/rasterio/exactextract, but cng_datasets.raster.cog imports
+    osgeo at module load, so these are gated on GDAL like the rest.
+    """
+
+    def test_explode_fractions_flattens_parallel_arrays(self):
+        import pandas as pd
+        from cng_datasets.raster.cog import _explode_fractions
+
+        df = pd.DataFrame({
+            "_h3_str": ["a", "b", "c"],
+            "unique": [np.array([11, 22]), np.array([33]), np.array([], dtype="int32")],
+            "frac": [np.array([0.6, 0.4]), np.array([1.0]), np.array([])],
+        })
+        out = _explode_fractions(df)
+        # One row per (cell, class); the empty (no-coverage) cell drops out.
+        assert list(out.columns) == ["_h3_str", "value", "frac"]
+        assert len(out) == 3
+        assert list(out.loc[out["_h3_str"] == "a", "value"]) == [11, 22]
+        assert out.loc[out["_h3_str"] == "a", "frac"].sum() == pytest.approx(1.0)
+        assert "c" not in out["_h3_str"].values
+
+    def test_explode_fractions_all_empty(self):
+        import pandas as pd
+        from cng_datasets.raster.cog import _explode_fractions
+
+        df = pd.DataFrame({
+            "_h3_str": ["a"],
+            "unique": [np.array([], dtype="int32")],
+            "frac": [np.array([])],
+        })
+        out = _explode_fractions(df)
+        assert len(out) == 0
+        assert list(out.columns) == ["_h3_str", "value", "frac"]
+
+    def _categorical_raster(self, tmp_path, nodata=None):
+        import rasterio
+        from rasterio.transform import from_origin
+        arr = np.array([
+            [11, 11, 22, 22],
+            [11, 33, 22, 22],
+            [33, 33, 33, 22],
+            [11, 11, 22, 33],
+        ], dtype="int16")
+        p = os.path.join(tmp_path, "cat.tif")
+        transform = from_origin(-122.0, 38.0, 0.01, 0.01)
+        kwargs = dict(driver="GTiff", height=4, width=4, count=1,
+                      dtype="int16", crs="EPSG:4326", transform=transform)
+        if nodata is not None:
+            kwargs["nodata"] = nodata
+        with rasterio.open(p, "w", **kwargs) as ds:
+            ds.write(arr, 1)
+        return p
+
+    def test_chunk_worker_fractions_returns_long_rows(self, tmp_path):
+        from shapely.geometry import box
+        from cng_datasets.raster.cog import _exact_extract_chunk
+
+        raster = self._categorical_raster(str(tmp_path))
+        # A "cell" fully inside the raster footprint: fractions sum to 1.0.
+        cell_wkt = box(-122.0, 37.96, -121.96, 38.0).wkt
+        out = _exact_extract_chunk((raster, "fractions", [(123, cell_wkt)]))
+        assert list(out.columns) == ["_h3_str", "value", "frac"]
+        assert set(out["value"]) == {11, 22, 33}
+        assert out["frac"].sum() == pytest.approx(1.0)
+
+    def test_chunk_worker_fractions_excludes_band_nodata(self, tmp_path):
+        from shapely.geometry import box
+        from cng_datasets.raster.cog import _exact_extract_chunk
+
+        # Band nodata declared: the worker (no nodata-clearing VRT) leaves it to
+        # exactextract, which excludes it — nodata-keeping is _hex_aggregate_h0's
+        # job via a no-nodata VRT, not the worker's.
+        raster = self._categorical_raster(str(tmp_path), nodata=33)
+        cell_wkt = box(-122.0, 37.96, -121.96, 38.0).wkt
+        out = _exact_extract_chunk((raster, "fractions", [(123, cell_wkt)]))
+        assert 33 not in out["value"].values
+        assert out["frac"].sum() == pytest.approx(1.0)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Closes #142.

## Problem

Categorical rasters are hexed with `--hex-resampling mode`, storing a single dominant class per H3 cell. That's lossy for area accounting: any mixed cell loses its minority classes to the mode, so per-class areas drift **both** directions and statewide totals come in low (~5% measured on `cwhr13` in boettiger-lab/ca-30x30#73).

## What this adds

A new `fractions` reducer (exact-extract method) that emits **per-class fractional pixel coverage per cell** instead of one mode class.

- Uses exactextract's `unique`+`frac` ops, written as **LONG** rows `(value, frac, h<res>, parents…)` — one per class present in each cell.
- Area of class X becomes a cheap, mass-conserving hex join, staying inside the H3 partitioned-join model (no raster zonal full-scan):
  ```sql
  SELECT class, SUM(frac * cell_area_at_res) AS acres FROM hex GROUP BY class;
  ```

### Schema choice: long

Per the issue's discussion we went with **long** (`(h, value, frac)`) over wide/MAP — it scales to high cardinality (`cwhr` 60+, NLCD) and the area query stays trivial. Trade-off: row count multiplies by mean classes-per-cell.

### nodata handling

nodata is carried as an **explicit class** (band nodata cleared via a `noData="none"` VRT; multi-fill codes collapsed to the primary first per #108), so:
- `frac` sums to **≤ 1** per cell,
- the nodata share is **recoverable** rather than silently inflating real classes (recovers the nodata part of the ~5%),
- cells that are *entirely* nodata are dropped (no nodata-only rows over open ocean); cells with a real class keep their nodata row,
- the remaining `1 - SUM(frac)` is the irreducible **outside-raster quantization** — reported, not papered over.

`mode` stays available (correct for single-dominant-class map styling). `fractions` is treated as categorical for COG overview resampling, like `mode`.

## Tests

- `TestFractionsWorker` — explode helper + chunk-worker fractions path (isolates the long-explode from the gdal VRT path).
- `TestMultiValueNodata::test_hex_fractions_*` — end-to-end on the multi-fill categorical fixture: long schema, all genuine classes present, per-cell `frac` ≤ 1, nodata kept as explicit `-9999` class, fill codes collapsed, pure-nodata cells dropped.

All 51 raster tests pass locally (GDAL 3.10.3 bindings).

## Follow-ups (not in this PR)

- Reprocessing the affected published datasets (`cwhr13`, `cwhr`, `cgls-lc100`, `nlcd-2024`, …) is tracked in the companion **data-workflows** issue.
- ⚠️ **Downstream agent**: please confirm the `fractions` output on the focal **cwhr** data and that query-side agents handle the long `(value, frac)` schema correctly before we reprocess broadly. Note the per-cell row-count multiplication (one row per class) — agents must `GROUP BY` class and weight by `frac`, not `COUNT(DISTINCT cell)`.