### PR TITLE
fix(#147): quote --source-url in generated convert command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- `workflow` now `shlex.quote`s each `--source-url` when interpolating it into the generated convert command, so URLs carrying `&` query strings (common for ArcGIS Hub / REST download endpoints) no longer break the `bash -c` step apart into background jobs (#147)
+
 ### Added
 - `--resolution-by-area` for variable-resolution (size-stratified) H3 hex tiling: each feature is hexed at the native resolution its planar `ST_Area` maps to, so very large polygons use a coarse resolution while small ones keep fine edges — avoiding the Pass-2 OOM / 2 GB parquet-page limit without dropping the whole dataset to a coarse resolution. Output carries a uniform union schema (one column per resolution, finer columns null in coarser tiers) plus a `native_res` column, preserving flat equality joins. The #107 oversized-feature guardrail now estimates each feature's cells at its own native resolution, so large features back off automatically (#98)
 

--- a/cng_datasets/k8s/workflows.py
+++ b/cng_datasets/k8s/workflows.py
@@ -10,6 +10,7 @@ from typing import Optional, Dict, Any, List, Union
 from pathlib import Path
 import math
 import re
+import shlex
 import yaml
 from .jobs import K8sJobManager
 from .armada import convert_workflow_to_armada
@@ -602,7 +603,7 @@ def generate_dataset_workflow(
     # Build generation command for documentation
     parent_res_str = ','.join(map(str, parent_resolutions))
     # Format source URLs for command recreation
-    source_urls_str = ' '.join([f'--source-url {url}' for url in source_urls])
+    source_urls_str = ' '.join([f'--source-url {shlex.quote(url)}' for url in source_urls])
     res_flag = (f"--resolution-by-area \"{resolution_by_area}\""
                 if resolution_by_area is not None
                 else f"--h3-resolution {h3_resolution}")
@@ -1207,8 +1208,11 @@ def _generate_convert_job(manager, dataset_name, source_urls, bucket, output_pat
     if isinstance(source_urls, str):
         source_urls = [source_urls]
 
-    # Build source URLs string (one per line for readability)
-    sources_str = " \\\n  ".join(source_urls)
+    # Build source URLs string (one per line for readability).
+    # Quote each URL: source URLs from ArcGIS Hub / REST endpoints carry query
+    # strings with '&', which bash (this runs under `bash -c`) would otherwise
+    # interpret as job control and split the command apart. See issue #147.
+    sources_str = " \\\n  ".join(shlex.quote(url) for url in source_urls)
 
     # Build the conversion command with optional layer parameter
     layer_flag = f" \\\n  --layer {layer}" if layer else ""

--- a/tests/test_k8s_workflows.py
+++ b/tests/test_k8s_workflows.py
@@ -138,6 +138,27 @@ class TestWorkflowGeneration:
             assert "test-bucket" in all_text
     
     @pytest.mark.timeout(5)
+    def test_convert_command_quotes_source_url(self):
+        """Source URLs with '&' query strings must be quoted so bash -c does
+        not split the command on job-control operators. Regression for #147."""
+        from cng_datasets.k8s.workflows import _generate_convert_job
+
+        url = "https://example.com/data?format=shp&a=1&b=2"
+        with tempfile.TemporaryDirectory() as tmpdir:
+            manager = K8sJobManager(namespace="biodiversity")
+            _generate_convert_job(
+                manager, "mre-test", url, "public-test",
+                Path(tmpdir), "https://github.com/x/y",
+            )
+            job = yaml.safe_load((Path(tmpdir) / "mre-test-convert.yaml").read_text())
+
+        convert_cmd = job["spec"]["template"]["spec"]["containers"][0]["command"][-1]
+        # The URL is passed as a single quoted argument (shlex.quote uses '...').
+        assert f"'{url}'" in convert_cmd
+        # And never appears bare, where bash would background on the first '&'.
+        assert f"\n  {url}" not in convert_cmd
+
+    @pytest.mark.timeout(5)
     def test_hex_job_chunked(self):
         """Test hex job uses automatic chunking (defaults when bucket doesn't exist)."""
         with tempfile.TemporaryDirectory() as tmpdir:


### PR DESCRIPTION
## Summary

Closes #147. `cng-datasets workflow` emitted `--source-url` **unquoted** into the generated convert command. Because that command runs under `bash -c`, a URL query string containing `&` (common for ArcGIS Hub / REST download endpoints) was parsed as job control — bash backgrounded everything up to the `&` and tried to run the trailing tokens as separate commands, failing with e.g.:

```
bash: line 3: s3://public-cdfw/swap-2015/provinces.parquet: No such file or directory
```

## Fix

`shlex.quote()` each source URL where it is interpolated into a shell command in `cng_datasets/k8s/workflows.py`:

- `_generate_convert_job` — the actual convert command (`*-convert.yaml`, which is embedded verbatim in `configmap.yaml`, so both copies are fixed).
- The documentation "regeneration command" written into the configmap comment, so it too is copy-paste safe.

## Verification

Ran the issue's MRE — the URL is now single-quoted:

```
'https://example.com/data?format=shp&a=1&b=2' \
```

Added regression test `test_convert_command_quotes_source_url`. `pytest -k convert` passes. Remaining raster-test failures in this env are pre-existing (`osgeo`/GDAL not installed locally), unrelated to this change.