### PR TITLE
fix(#145): split transmeridian polygons before H3 polyfill

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Fixed
+- Vector H3 hex now splits circumpolar / transmeridian polygons (longitude-bbox span > 180°) into sub-180° longitude bands before polyfill, so they fill their full band instead of collapsing to ~1 cell. H3 `polygon_to_cells` reads a >180° ring as the minimal-area (complement) side; a full −180..180 band (e.g. CCAMLR's Southern-Ocean RFB) previously produced ~1 cell instead of millions. Narrow (<180°-span) polygons keep the original fast path unchanged (#145)
 - `workflow` now `shlex.quote`s each `--source-url` when interpolating it into the generated convert command, so URLs carrying `&` query strings (common for ArcGIS Hub / REST download endpoints) no longer break the `bash -c` step apart into background jobs (#147)
 
 ### Added

--- a/cng_datasets/vector/h3_tiling.py
+++ b/cng_datasets/vector/h3_tiling.py
@@ -133,6 +133,49 @@ def _native_res_case_sql(bins: List[Tuple[Optional[float], int]], geom_expr: str
     return "CASE " + " ".join(whens) + f" ELSE {catchall} END"
 
 
+# H3 polygon_to_cells interprets a ring whose exterior spans more than 180 deg of
+# longitude as the minimal-area (complement) side, so a circumpolar / transmeridian
+# polygon fills ~nothing — e.g. a full -180..180 band yields ~1 cell instead of the
+# millions its area implies (issue #145). Before polyfill we split any polygon whose
+# longitude-bbox span exceeds 180 deg into sub-180-deg longitude bands, intersect
+# the polygon with each, and polyfill the pieces. Each band must be strictly < 180
+# deg wide (a 180-deg band is itself ambiguous and also fills ~nothing); four 90-deg
+# strips tile the whole -180..180 range with margin to spare.
+_TRANSMERIDIAN_MAX_SPAN_DEG = 180
+_TRANSMERIDIAN_BANDS = [(-180, -90), (-90, 0), (0, 90), (90, 180)]
+
+
+def _transmeridian_split_sql(carry_cols: str, source: str) -> str:
+    """SQL for a CTE body that splits >180-deg-longitude-span polygons into bands.
+
+    Rows from ``source`` whose longitude bbox span is <= 180 deg pass through
+    unchanged (the common fast path); wider rows are cross-joined with the
+    longitude bands and intersected, so downstream ST_Dump + H3 polyfill only ever
+    see sub-180-deg pieces. The intersection may yield a MULTIPOLYGON or
+    GEOMETRYCOLLECTION, which the existing ST_Dump step already splits into single
+    geometries before polyfill.
+
+    Args:
+        carry_cols: comma-separated non-geometry columns to propagate (e.g. the id
+            column, plus ``native_res`` in variable-resolution mode).
+        source: name of the upstream CTE exposing those columns and a ``geom`` column.
+    """
+    bands = ', '.join(
+        f"(ST_GeomFromText('POLYGON(({lo} -90, {hi} -90, {hi} 90, {lo} 90, {lo} -90))'))"
+        for lo, hi in _TRANSMERIDIAN_BANDS
+    )
+    return f'''
+            SELECT {carry_cols}, geom
+            FROM {source}
+            WHERE ST_XMax(geom) - ST_XMin(geom) <= {_TRANSMERIDIAN_MAX_SPAN_DEG}
+            UNION ALL
+            SELECT {carry_cols}, ST_Intersection(s.geom, _bands.band) AS geom
+            FROM {source} AS s, (VALUES {bands}) AS _bands(band)
+            WHERE ST_XMax(s.geom) - ST_XMin(s.geom) > {_TRANSMERIDIAN_MAX_SPAN_DEG}
+              AND ST_Intersects(s.geom, _bands.band)
+    '''
+
+
 def _h3_edge_length_degrees(resolution: int) -> float:
     """Return the H3 edge length in degrees for a given resolution.
 
@@ -330,10 +373,11 @@ def geom_to_h3_cells(
                    END AS geom
             FROM tbase
         ),
+        tsplit AS ({_transmeridian_split_sql(f'{col_list}, native_res', 't0')}),
         t1 AS (
             SELECT {col_list}, native_res,
                    UNNEST(ST_Dump(geom)).geom AS geom
-            FROM t0
+            FROM tsplit
         ),
         t2 AS (
             SELECT {col_list}, native_res, geom,
@@ -383,10 +427,11 @@ def geom_to_h3_cells(
                    END AS geom
             FROM {table_name}
         ),
+        tsplit AS ({_transmeridian_split_sql(col_list, 't0')}),
         t1 AS (
             SELECT {col_list},
                    UNNEST(ST_Dump(geom)).geom AS geom
-            FROM t0
+            FROM tsplit
         ),
         t2 AS (
             SELECT {col_list},

--- a/tests/test_vector.py
+++ b/tests/test_vector.py
@@ -356,8 +356,61 @@ class TestH3Functions:
         
         # Parent cells should be different from child
         assert result['h10'].iloc[0] != result['h9'].iloc[0]
-        
+
         con.close()
+
+    @pytest.mark.timeout(20)
+    def test_circumpolar_polygon_is_split_before_polyfill(self):
+        """A polygon spanning the full 360 deg of longitude must fill its band,
+        not collapse to ~1 cell. H3 polygon_to_cells reads a >180-deg ring as the
+        minimal-area side, so the pipeline splits it into <180-deg bands (#145)."""
+        con = setup_duckdb_connection()
+        # Full -180..180 x -78..-50 band (CCAMLR-shaped) plus a normal box.
+        con.execute("""
+            CREATE TABLE feats AS
+            SELECT 'ccamlr' AS id,
+                   ST_GeomFromText('POLYGON((-180 -78,180 -78,180 -50,-180 -50,-180 -78))') AS geom
+            UNION ALL
+            SELECT 'normal' AS id,
+                   ST_GeomFromText('POLYGON((-100 -70,-50 -70,-50 -50,-100 -50,-100 -70))') AS geom
+        """)
+        sql = geom_to_h3_cells(con, "feats", zoom=3, keep_cols=['id'])
+        con.execute(f"CREATE TABLE arrs AS SELECT * FROM ({sql})")
+
+        # Circumpolar feature now fills thousands of cells (was ~0 before the split).
+        n_ccamlr = con.execute(
+            "SELECT sum(len(h3id)) FROM arrs WHERE id = 'ccamlr'"
+        ).fetchone()[0]
+        assert n_ccamlr > 1000, f"circumpolar band should fill its band, got {n_ccamlr}"
+
+        # Band boundaries must not double-count cells (each cell centre lands in one band).
+        distinct, total = con.execute("""
+            SELECT count(DISTINCT cell), count(*)
+            FROM (SELECT UNNEST(h3id) AS cell FROM arrs WHERE id = 'ccamlr')
+        """).fetchone()
+        assert distinct == total, f"band split duplicated {total - distinct} boundary cells"
+
+        # The normal polygon is untouched: single row via the fast path.
+        n_rows_normal = con.execute(
+            "SELECT count(*) FROM arrs WHERE id = 'normal'"
+        ).fetchone()[0]
+        assert n_rows_normal == 1, "sub-180-deg polygon should not be band-split"
+        con.close()
+
+    @pytest.mark.timeout(20)
+    def test_circumpolar_polygon_split_variable_resolution(self):
+        """The transmeridian split also applies on the variable-resolution path (#145)."""
+        con = setup_duckdb_connection()
+        con.execute("""
+            CREATE TABLE feats AS
+            SELECT 'ccamlr' AS id,
+                   ST_GeomFromText('POLYGON((-180 -78,180 -78,180 -50,-180 -50,-180 -78))') AS geom
+        """)
+        rba = parse_resolution_by_area("12:5,3")  # large features hex at res 3
+        sql = geom_to_h3_cells(con, "feats", zoom=8, keep_cols=['id'], resolution_by_area=rba)
+        n = con.execute(f"SELECT sum(len(h3id)) FROM ({sql})").fetchone()[0]
+        con.close()
+        assert n > 1000, f"circumpolar band should fill its band on the var-res path, got {n}"
 
 
 class TestLineGeometryH3:


### PR DESCRIPTION
## Summary

Closes #145. `cng-datasets vector` hex silently produced **~1 cell** for a polygon whose exterior ring spans the full 360° of longitude (a circumpolar / transmeridian polygon) instead of the millions its area implies. H3 `polygon_to_cells` interprets a ring spanning >180° of longitude as the **minimal-area (complement) side**, so it fills ~nothing. This hit `public-high-seas/rfmo/rfb` — CCAMLR (a −180..180 × −88..−45 Southern-Ocean band) was reduced to 1 h8 cell.

I confirmed the H3 behaviour is monotonic: as span grows past 180°, the filled cell count *decreases* toward 0 near 360° (H3 keeps filling the shrinking complement):

| span | cells (res 3) |
|------|------|
| 180.0° | 1099 |
| 200° | 925 |
| 300° | 390 |
| 359.9° | 0 |

## Fix

In `geom_to_h3_cells`, before the existing `ST_Dump` + polyfill, split any polygon whose **longitude-bbox span > 180°** into four **90°-wide longitude bands** (`ST_Intersection` with `[-180,-90], [-90,0], [0,90], [90,180]` strips). Each piece is then <180° wide, so polyfill works. Key points:

- **Bands must be strictly <180° wide** — a 180° band is itself ambiguous (the issue notes a naive hemisphere split fails). 4×90° tiles the range with margin.
- Splitting happens **before `ST_Dump`**, because `h3_polygon_wkt_to_cells` returns 0 for a MULTIPOLYGON, and an intersection can produce MULTIPOLYGON/GEOMETRYCOLLECTION — the existing `ST_Dump` step already breaks those into single geometries.
- **Narrow (<180°-span) polygons pass through unchanged** via a `UNION ALL` fast path — no intersection cost, no behaviour change.
- Applied to **both** the fixed-zoom and variable-resolution (`--resolution-by-area`) SQL paths.
- Antimeridian-crossing narrow polygons stored with a wide bbox are caught by the same span test.

## Verification

Reproduced the issue's MRE, then verified the generated SQL end-to-end:

- Circumpolar `POLYGON((-180 -78,180 -78,180 -50,-180 -50,-180 -78))` at res 3: **0 → 4426 cells**, matching a reference 4-box union exactly, split across 4 band-rows with **zero** boundary duplicates.
- Normal box: unchanged (490 cells, single row).
- Same result on the variable-resolution path.

Added regression tests `test_circumpolar_polygon_is_split_before_polyfill` and `test_circumpolar_polygon_split_variable_resolution`. Full `test_vector.py` + `test_hex_checks.py` suites pass (63 passed). Raster tests are skipped locally (no `osgeo`), unrelated to this change.