### PR TITLE
fix(#153): rewrite s3:// vector sources to /vsicurl for ST_Read

### DIFF
--- a/cng_datasets/vector/convert_to_parquet.py
+++ b/cng_datasets/vector/convert_to_parquet.py
@@ -195,6 +195,31 @@ def is_parquet_file(source_url: str) -> bool:
     return path.lower().endswith('.parquet')
 
 
+def to_gdal_readable(url: str) -> str:
+    """
+    Rewrite a remote source URL into a GDAL /vsicurl path so ST_Read can open it.
+
+    GDAL cannot open a bare ``s3://`` path without /vsis3 credentials configured,
+    and this tool does not set them (issue #153). The NRP object store is reachable
+    over plain HTTPS, so ``s3://bucket/key`` is rewritten to its public HTTPS
+    endpoint and then streamed via /vsicurl. Plain ``http(s)://`` URLs are wrapped
+    in /vsicurl too. Already-VSI (``/vsi*``) and local paths pass through unchanged.
+
+    Args:
+        url: Source dataset URL or path
+
+    Returns:
+        A GDAL-openable path for ST_Read.
+    """
+    if url.startswith('/vsi'):
+        return url
+    if url.startswith('s3://'):
+        url = f"https://s3-west.nrp-nautilus.io/{url[len('s3://'):]}"
+    if url.lower().startswith(('http://', 'https://')):
+        return f"/vsicurl/{url}"
+    return url
+
+
 def download_and_extract(url: str, extract_to: str, verbose: bool = False) -> None:
     """
     Download a file from a URL and extract it if it is a zip file.
@@ -925,18 +950,16 @@ def convert_to_parquet(
             print(f"  Processing {len(source_urls)} input files...")
             processed_sources = []
             for url in source_urls:
-                # Handle HTTP(S) for GDAL/DuckDB ST_Read
-                if url.lower().startswith(('http://', 'https://')) and not url.startswith('/vsi'):
-                    processed_sources.append(f"/vsicurl/{url}")
-                else:
-                    processed_sources.append(url)
+                # Rewrite s3:// and HTTP(S) sources into GDAL /vsicurl paths so
+                # ST_Read can open them (issue #153).
+                processed_sources.append(to_gdal_readable(url))
             source_inputs = processed_sources
             representative_source = processed_sources[0]
         else:
             # Single non-zip source
-            # Handle HTTP(S) for GDAL/DuckDB ST_Read
-            if source_urls[0].lower().startswith(('http://', 'https://')) and not source_urls[0].startswith('/vsi'):
-                 source_urls[0] = f"/vsicurl/{source_urls[0]}"
+            # Rewrite s3:// and HTTP(S) sources into GDAL /vsicurl paths so
+            # ST_Read can open them (issue #153).
+            source_urls[0] = to_gdal_readable(source_urls[0])
             source_inputs = source_urls[0]
             representative_source = source_urls[0]
 

--- a/tests/test_convert_to_parquet.py
+++ b/tests/test_convert_to_parquet.py
@@ -14,7 +14,32 @@ from cng_datasets.vector.convert_to_parquet import (
     DEFAULT_ROW_GROUP_BYTES,
     find_vector_sources,
     download_and_extract,
+    to_gdal_readable,
 )
+
+
+class TestToGdalReadable:
+    """s3:// and http(s):// sources must be rewritten so ST_Read (GDAL) can open
+    them; GDAL cannot open a bare s3:// path without /vsis3 config (#153)."""
+
+    def test_s3_rewritten_to_vsicurl_public_endpoint(self):
+        assert to_gdal_readable(
+            "s3://public-cdfw/raw/fish-passage-pad.geojson"
+        ) == "/vsicurl/https://s3-west.nrp-nautilus.io/public-cdfw/raw/fish-passage-pad.geojson"
+
+    def test_http_wrapped_in_vsicurl(self):
+        assert to_gdal_readable(
+            "https://example.org/data.gpkg"
+        ) == "/vsicurl/https://example.org/data.gpkg"
+
+    def test_vsi_paths_pass_through(self):
+        vsi = "/vsicurl/https://example.org/data.gpkg"
+        assert to_gdal_readable(vsi) == vsi
+        assert to_gdal_readable("/vsis3/bucket/key.shp") == "/vsis3/bucket/key.shp"
+
+    def test_local_paths_pass_through(self):
+        assert to_gdal_readable("/tmp/local.geojson") == "/tmp/local.geojson"
+        assert to_gdal_readable("data.shp") == "data.shp"
 
 
 class TestReprojectQueryAxisOrder:


### PR DESCRIPTION
Closes #153.

## Problem
`cng-convert-to-parquet <s3://…geojson> <s3://…parquet>` fails at the read step: CRS/geometry detection (DuckDB httpfs / geopandas) succeeds, but the read builds `ST_Read('s3://…geojson')`, and GDAL cannot open a bare `s3://` path without `/vsis3` credentials the tool never sets. A parquet source works because it goes through httpfs (`read_parquet`), not GDAL — the ST_Read-vs-parquet asymmetry.

## Fix
Add `to_gdal_readable(url)`, which rewrites `s3://bucket/key` to its public HTTPS endpoint (`https://s3-west.nrp-nautilus.io/…`) wrapped in `/vsicurl/`, and wraps plain `http(s)://` in `/vsicurl/` too. `/vsi*` and local paths pass through. This mirrors both the existing single/multi-source http handling and the parquet read path's s3→https rewrite. Applied in the single- and multi-source non-zip branches (zip and parquet sources were already handled separately).

## Tests
New `TestToGdalReadable` covers s3://, http(s)://, `/vsi*` passthrough, and local passthrough. `ruff` clean.