### PR TITLE
fix(#154): raise soft fd limit before tippecanoe in pmtiles job

### DIFF
--- a/cng_datasets/k8s/workflows.py
+++ b/cng_datasets/k8s/workflows.py
@@ -1323,6 +1323,13 @@ ogr2ogr -wrapdateline -datelineoffset 15 -f GeoJSONSeq /tmp/$DATASET.geojsonl /v
 # environment, not the shell. A plain assignment is invisible to it, so it
 # falls back to the raw (non-power-of-2) CPU count and crashes (issue #77).
 export TIPPECANOE_MAX_THREADS=$(python3 -c "import os; n=os.cpu_count() or 1; print(1<<(n.bit_length()-1))")
+
+# Raise the soft open-file limit before tippecanoe (issue #154). It opens many
+# temp files (per-thread x per-tile shards); on high-core nodes os.cpu_count()
+# reports the node's full core count, so the thread/shard count blows past the
+# container's default soft nofile limit (often 1024) and aborts with
+# "Too many open files". `|| true` keeps going if the limit can't be raised.
+ulimit -n 65536 || true
 tippecanoe -o /tmp/$DATASET.pmtiles -l $DATASET --coalesce-densest-as-needed --drop-densest-as-needed -z {_pmtiles_max_zoom(h3_resolution, max_zoom)} --force /tmp/$DATASET.geojsonl
 
 # Upload to S3 using rclone

--- a/tests/test_k8s_workflows.py
+++ b/tests/test_k8s_workflows.py
@@ -297,6 +297,25 @@ class TestWorkflowGeneration:
             # A plain (un-exported) assignment is invisible to the child process.
             assert "export TIPPECANOE_MAX_THREADS=" in command
 
+    def test_pmtiles_job_raises_open_file_limit(self):
+        """Soft fd limit must be raised before tippecanoe on high-core nodes (#154)."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            generate_dataset_workflow(
+                dataset_name="test-ds",
+                source_url="https://s3-west.nrp-nautilus.io/public-test/fixtures/test-fixture.gpkg",
+                bucket="test-bucket",
+                output_dir=tmpdir,
+            )
+
+            pmtiles_file = Path(tmpdir) / "test-ds-pmtiles.yaml"
+            with open(pmtiles_file) as f:
+                job = yaml.safe_load(f)
+
+            command = job["spec"]["template"]["spec"]["containers"][0]["command"][2]
+            # ulimit must precede tippecanoe, and tolerate an unraisable limit.
+            assert "ulimit -n" in command
+            assert command.index("ulimit -n") < command.index("tippecanoe -o")
+
     @pytest.mark.timeout(5)
     def test_pmtiles_max_zoom_derived_from_h3_resolution(self):
         """PMTiles max zoom defaults to h3_resolution+3; --extend-zooms removed (#133)."""


### PR DESCRIPTION
Closes #154.

## Problem
The pmtiles job runs tippecanoe with `TIPPECANOE_MAX_THREADS` = largest power-of-2 ≤ `os.cpu_count()`. In a container, `os.cpu_count()` reports the **node's** full logical core count, not the pod's CPU limit, so on a high-core node the thread count is large and tippecanoe's per-thread × per-tile temp shards exhaust the container's default soft `nofile` limit (often 1024), aborting with `Too many open files`. Observed in data-workflows #398; re-running with `ulimit -n 65536` first succeeded.

## Fix
Emit `ulimit -n 65536 || true` in the generated pmtiles command, right before tippecanoe. `|| true` keeps the job going if the limit can't be raised in a locked-down environment. The existing power-of-2 thread logic (issue #77) is left intact.

## Tests
New `test_pmtiles_job_raises_open_file_limit` asserts the `ulimit -n` appears and precedes `tippecanoe -o`. `ruff` clean.