### PR TITLE
fix(#150): de-duplicate (feature, cell) rows in vector hex output

### DIFF
--- a/cng_datasets/vector/h3_tiling.py
+++ b/cng_datasets/vector/h3_tiling.py
@@ -935,10 +935,23 @@ class H3VectorProcessor:
             if (batch_id + 1) % 10 == 0 or batch_id == num_batches - 1:
                 print(f"  Progress: {batch_id + 1}/{num_batches} batches")
 
-        # Final step: copy completed file to S3 (single write operation)
+        # Final step: copy completed file to S3 (single write operation).
+        #
+        # De-duplicate (feature, cell) rows here (issue #150). Pass 1 dumps each
+        # feature into one row PER PART (UNNEST(ST_Dump)), and Pass 2 unnests every
+        # part's cell array independently, so a cell touched by >= 2 parts of the
+        # same MultiPolygon (shared part boundaries; complex coastlines / island
+        # fringes) is emitted once per part — byte-identical duplicate rows that
+        # silently inflate every downstream SUM/area aggregate. Every column is a
+        # deterministic function of (id, cell), so DISTINCT * removes exactly the
+        # excess and keeps legitimately distinct rows (different features covering
+        # the same cell keep their distinct id). This must run on the fully
+        # assembled per-chunk file rather than per Pass-2 batch: one feature's
+        # parts can span multiple batches, and each feature lives entirely within
+        # one chunk, so a per-chunk DISTINCT is both complete and sufficient.
         print(f"  Writing final output to {final_output}...")
         self.con.execute(f"""
-            COPY (SELECT * FROM read_parquet('{local_output}'))
+            COPY (SELECT DISTINCT * FROM read_parquet('{local_output}'))
             TO '{final_output}'
             (FORMAT PARQUET, COMPRESSION 'ZSTD', ROW_GROUP_SIZE 100000)
         """)

--- a/tests/test_vector.py
+++ b/tests/test_vector.py
@@ -722,6 +722,74 @@ class TestVectorProcessing:
             result_con.close()
             processor.con.close()
     
+    @pytest.mark.timeout(15)
+    def test_multipolygon_no_duplicate_feature_cell_rows(self):
+        """A MultiPolygon whose parts share cells must not emit duplicate
+        (feature, cell) rows (issue #150).
+
+        Two overlapping parts polyfill to overlapping cell sets. Before the fix,
+        Pass 2 unnested each part independently and wrote a row per part per cell,
+        byte-identically duplicating every shared cell and inflating downstream
+        SUM/area aggregates. intermediate_chunk_size=1 forces the two parts into
+        separate Pass-2 batches, so this also proves the dedup happens on the
+        fully assembled per-chunk file, not merely within a batch.
+        """
+        with tempfile.TemporaryDirectory() as tmpdir:
+            con = setup_duckdb_connection()
+            test_parquet = f"{tmpdir}/test.parquet"
+            # fid=1: MultiPolygon with two overlapping parts (guaranteed shared
+            #        cells). fid=2: a single-part Polygon control (never dup'd).
+            con.execute(f"""
+                CREATE TABLE test_data AS
+                SELECT * FROM (VALUES
+                    (1, ST_GeomFromText('MULTIPOLYGON(((-122.5 37.7,-122.4 37.7,-122.4 37.8,-122.5 37.8,-122.5 37.7)),((-122.45 37.72,-122.35 37.72,-122.35 37.82,-122.45 37.82,-122.45 37.72)))')),
+                    (2, ST_GeomFromText('POLYGON((-121.5 36.7,-121.4 36.7,-121.4 36.8,-121.5 36.8,-121.5 36.7))'))
+                ) t(id, geom)
+            """)
+            con.execute(f"COPY test_data TO '{test_parquet}' (FORMAT PARQUET)")
+            con.close()
+
+            os.environ['AWS_ACCESS_KEY_ID'] = ''
+            os.environ['AWS_SECRET_ACCESS_KEY'] = ''
+
+            processor = H3VectorProcessor(
+                input_url=test_parquet,
+                output_url=tmpdir,
+                h3_resolution=8,
+                parent_resolutions=[0],
+                chunk_size=10,
+                intermediate_chunk_size=1,  # force parts into separate pass-2 batches
+            )
+            output_file = processor.process_chunk(0)
+            processor.con.close()
+
+            rc = setup_duckdb_connection()
+            try:
+                total, distinct = rc.execute(f"""
+                    SELECT COUNT(*), COUNT(DISTINCT (id, h8))
+                    FROM read_parquet('{output_file}')
+                """).fetchone()
+                assert total == distinct, (
+                    f"duplicate (feature, cell) rows: {total} rows vs {distinct} distinct"
+                )
+
+                # The multipart feature must still cover cells (fix removes dupes,
+                # not the feature) and no single (id, cell) may repeat.
+                worst = rc.execute(f"""
+                    SELECT MAX(n) FROM (
+                        SELECT COUNT(*) n FROM read_parquet('{output_file}')
+                        GROUP BY id, h8
+                    )
+                """).fetchone()[0]
+                assert worst == 1, f"a (feature, cell) pair repeats {worst} times"
+
+                ids = {r[0] for r in rc.execute(
+                    f"SELECT DISTINCT id FROM read_parquet('{output_file}')"
+                ).fetchall()}
+                assert ids == {1, 2}, f"expected both features present, got {ids}"
+            finally:
+                rc.close()
+
     @pytest.mark.timeout(5)
     def test_h3_vector_processor_process_chunk(self):
         """Test processing a single chunk of vector data."""


### PR DESCRIPTION
Closes #150.

## Problem
The vector hex step emits **byte-identical duplicate `(feature, H3 cell)` rows** for MultiPolygon features. Pass 1 dumps each feature into one row *per part* (`UNNEST(ST_Dump)`), each with its own H3 cell array; Pass 2 unnests every part's array independently and writes without any dedup. A cell touched by ≥2 parts of the same feature (shared part boundaries, complex coastlines, island fringes) is written once per part. Single-part Polygons are unaffected.

Downstream this silently inflates every `SUM(...)`/area aggregate. Found in production on `ca30x30-ecoregion` (fid=4, a 4013-part MultiPolygon: 27,717 rows for 24,043 distinct cells → 3,674 excess), and affects any dataset with multipart geometry (coastlines, island chains, exclaves, WDPA, NWI…).

## Fix
De-duplicate with `SELECT DISTINCT *` on the **fully assembled per-chunk file** at the final write in `_process_pass2`. Every output column is a deterministic function of `(id, cell)`, so `DISTINCT *` removes exactly the byte-identical excess and preserves legitimately distinct rows (different features covering the same cell keep their distinct id — ids are unique per feature in this pipeline).

Placement matters: the dedup runs on the assembled chunk output, **not** per Pass-2 batch, because one feature's parts can span multiple batches (the MRE uses `--intermediate-chunk-size 10` against a 4013-part feature). Each feature lives entirely within one chunk (chunking is by source row), so per-chunk `DISTINCT` is both complete and sufficient — no cross-chunk duplication is possible.

## Tests
New `test_multipolygon_no_duplicate_feature_cell_rows`: a two-overlapping-part MultiPolygon (guaranteed shared cells) plus a single-part control, processed with `intermediate_chunk_size=1` to force the parts into separate Pass-2 batches. Asserts `COUNT(*) == COUNT(DISTINCT (id, h8))`, no `(id, cell)` repeats, and both features survive. Verified the test **fails without** the fix (duplicates present) and passes with it. Full `test_vector.py` (60 tests) green; `ruff` clean.