### PR TITLE
fix(#151): compute 4326 src bounds via AutoCreateWarpedVRT (global Mollweide)

### DIFF
--- a/cng_datasets/raster/cog.py
+++ b/cng_datasets/raster/cog.py
@@ -1112,24 +1112,54 @@ class RasterProcessor:
         src_srs = osr.SpatialReference()
         src_srs.ImportFromWkt(ds.GetProjection())
         src_srs.SetAxisMappingStrategy(osr.OAMS_TRADITIONAL_GIS_ORDER)
-        ds = None
 
         if src_srs.IsGeographic():
+            ds = None
             return (min(xmin, xmax), min(ymin, ymax), max(xmin, xmax), max(ymin, ymax))
 
+        # Projected source: compute the EPSG:4326 extent the way gdalwarp does,
+        # via AutoCreateWarpedVRT. Transforming only the four rectangular-extent
+        # corners point-by-point is unsafe for a global equal-area projection
+        # such as World Mollweide (ESRI:54009): the rectangle's corners fall in
+        # the projection's undefined oval corners, so the transform raises
+        # "Point outside of projection domain" and crashes __init__ before any
+        # work is done (issue #151). Densifying the rectangle edges doesn't help
+        # either — every edge point of the bounding rectangle is still in the
+        # undefined region, which collapses the longitude span. AutoCreateWarpedVRT
+        # samples the raster the way the warp machinery itself does (this is the
+        # file gdalwarp -t_srs EPSG:4326 handles fine) and yields a correct,
+        # domain-safe extent.
         tgt_srs = osr.SpatialReference()
         tgt_srs.ImportFromEPSG(4326)
         tgt_srs.SetAxisMappingStrategy(osr.OAMS_TRADITIONAL_GIS_ORDER)
-        transform = osr.CoordinateTransformation(src_srs, tgt_srs)
-        corners = [
-            transform.TransformPoint(xmin, ymin),
-            transform.TransformPoint(xmin, ymax),
-            transform.TransformPoint(xmax, ymin),
-            transform.TransformPoint(xmax, ymax),
-        ]
-        lons = [c[0] for c in corners]
-        lats = [c[1] for c in corners]
-        return (min(lons), min(lats), max(lons), max(lats))
+
+        bounds = None
+        try:
+            vrt = gdal.AutoCreateWarpedVRT(ds, ds.GetProjection(), tgt_srs.ExportToWkt())
+            if vrt is not None:
+                vgt = vrt.GetGeoTransform()
+                vxmin = vgt[0]
+                vxmax = vgt[0] + vgt[1] * vrt.RasterXSize
+                vymax = vgt[3]
+                vymin = vgt[3] + vgt[5] * vrt.RasterYSize
+                vrt = None
+                if all(math.isfinite(v) for v in (vxmin, vymin, vxmax, vymax)):
+                    bounds = (min(vxmin, vxmax), min(vymin, vymax),
+                              max(vxmin, vxmax), max(vymin, vymax))
+        except RuntimeError:
+            bounds = None
+        finally:
+            ds = None
+
+        if bounds is None:
+            # Last-resort safe over-approximation: the whole globe. These bounds
+            # are only used to clip/skip h0 regions during hex aggregation, so an
+            # over-approximation is safe (it just skips fewer regions) while an
+            # under-approximation would silently drop real data. Better than the
+            # historic crash.
+            print("  ⚠ Could not compute reprojected bounds; assuming global extent.")
+            bounds = (-180.0, -90.0, 180.0, 90.0)
+        return bounds
 
     def create_cog(
         self,

--- a/tests/test_raster.py
+++ b/tests/test_raster.py
@@ -6,6 +6,7 @@ Tests COG creation, H3 tiling, and resolution detection using small test dataset
 
 import pytest
 import os
+import math
 import tempfile
 import shutil
 from pathlib import Path
@@ -177,6 +178,25 @@ class TestRasterProcessor:
         ds = None
         return raster_path
 
+    @pytest.fixture
+    def global_mollweide_raster(self, temp_dir):
+        """Global World Mollweide (ESRI:54009) raster whose rectangular extent
+        exceeds the projection's valid oval domain (#151)."""
+        from osgeo import gdal, osr
+        width, height = 361, 181
+        raster_path = os.path.join(temp_dir, "global_mollweide.tif")
+        driver = gdal.GetDriverByName("GTiff")
+        ds = driver.Create(raster_path, width, height, 1, gdal.GDT_Float32)
+        # Full Mollweide globe: x half-width ~1.804e7 m, y half-height ~9.02e6 m.
+        ds.SetGeoTransform([-18040000, 100000, 0, 9020000, 0, -100000])
+        srs = osr.SpatialReference()
+        srs.SetFromUserInput("ESRI:54009")
+        ds.SetProjection(srs.ExportToWkt())
+        ds.GetRasterBand(1).WriteArray(np.ones((height, width), dtype=np.float32))
+        ds.GetRasterBand(1).FlushCache()
+        ds = None
+        return raster_path
+
     @pytest.mark.timeout(30)
     def test_raster_processor_init_no_epsg_srs(self, esri102003_raster):
         """RasterProcessor.__init__ must not crash on a raster with no EPSG authority code (#131)."""
@@ -184,6 +204,25 @@ class TestRasterProcessor:
         # Should not raise RuntimeError from AutoIdentifyEPSG
         proc = RasterProcessor(esri102003_raster, local_cache_dir=None)
         assert proc.input_path is not None
+
+    @pytest.mark.timeout(30)
+    def test_raster_processor_init_global_mollweide(self, global_mollweide_raster):
+        """__init__ must not crash computing 4326 bounds for a global Mollweide
+        raster whose bbox corners fall in the undefined projection domain (#151).
+
+        Previously _compute_src_bounds_4326 transformed the rectangular corners
+        point-by-point and raised "Point outside of projection domain". The bounds
+        are used only to clip/skip h0 regions, so they must be a safe superset of
+        the true extent: near-full longitude and latitude within [-90, 90].
+        """
+        from cng_datasets.raster.cog import RasterProcessor
+        proc = RasterProcessor(global_mollweide_raster, local_cache_dir=None)
+        xmin, ymin, xmax, ymax = proc._src_bounds_4326
+        assert all(math.isfinite(v) for v in (xmin, ymin, xmax, ymax))
+        # A global raster must span essentially the whole longitude range; a
+        # collapsed/undersized box here would silently drop data downstream.
+        assert xmin <= -179.0 and xmax >= 179.0, f"longitude not global: {(xmin, xmax)}"
+        assert -90.0 <= ymin < ymax <= 90.0, f"latitude out of range: {(ymin, ymax)}"
 
     @pytest.mark.timeout(30)
     def test_detect_nodata_value(self, small_raster):


### PR DESCRIPTION
Closes #151.

## Problem
`RasterProcessor.__init__` crashes with `RuntimeError: Point outside of projection domain` when the input is a global equal-area projection whose rectangular extent exceeds the valid projection domain — e.g. World Mollweide (ESRI:54009), as in the Theobald gHM import. `_compute_src_bounds_4326()` runs unconditionally in `__init__` and transforms the raster's rectangular-extent corners point-by-point; for a global Mollweide the corners fall in the projection's undefined oval corners, so `osr.CoordinateTransformation.TransformPoint` raises. Both `--output-cog` and `--output-parquet` (hex) paths crash before doing any work. `gdalwarp -t_srs EPSG:4326` handles the file fine.

## Fix
Replace the 4-corner transform with `gdal.AutoCreateWarpedVRT` — the same warp machinery `gdalwarp` uses internally — and read the reprojected extent from the warped VRT's geotransform. This is domain-safe: it samples the raster the way the warp does rather than blindly transforming bbox corners.

I verified both GDAL error modes produce a **safe superset** of the true extent (these bounds are only used to clip/skip h0 regions during hex aggregation, so over-approximating is safe; under-approximating would silently drop data):
- exceptions **off**: returns the correct tight-ish extent, e.g. `(-180, 180, -89.4, 89.99)` for global Mollweide;
- exceptions **on**: `AutoCreateWarpedVRT` raises on the domain issue → caught → safe whole-globe fallback `(-180, -90, 180, 90)`.

Regional projected rasters (UTM, Albers) still get tight correct bounds either way (verified UTM 10N → `(-123.0, -122.9, 37.86, 37.95)`).

## Tests
New `test_raster_processor_init_global_mollweide` builds a full-globe ESRI:54009 raster and asserts `__init__` doesn't crash and the bounds are a safe superset (near-full longitude, latitude within [-90, 90]). Verified it **fails without** the fix (the exact `Point outside of projection domain`) and passes with it.

Note on local validation: the repo intentionally omits GDAL from PyPI deps (Docker/CI ship system GDAL 3.13 via `--system-site-packages`). I ran this test against a local GDAL **3.10.3** venv, where it and the sibling init/CRS/`create_cog` tests pass; the `AutoCreateWarpedVRT` API is stable across 3.4–3.13, and CI runs the suite on 3.13. `ruff` clean.