### PR TITLE
docs: add Zenodo citation metadata and DOI badge

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -181,6 +181,7 @@ cython_debug/
 *.wal
 *.duckdb
 *.json
+!.zenodo.json
 *.shp
 *.xml
 *.sbn

--- a/.zenodo.json
+++ b/.zenodo.json
@@ -1,0 +1,24 @@
+{
+   "creators":[
+      {
+         "name":"Boettiger, Carl",
+         "orcid":"0000-0002-1642-628X",
+         "affiliation":"University of California Berkeley"
+      },
+      {
+         "name":"Buhler, Cassidy Kim",
+         "orcid":"0000-0003-4157-4273",
+         "affiliation":"University of Colorado Boulder"
+      }
+   ],
+   "title":"cng-datasets: A cloud-native toolkit for processing large geospatial datasets on Kubernetes",
+   "description":"A CLI toolkit that turns source geospatial data (Shapefiles, GeoPackages, FileGDB, GeoTIFFs) into cloud-native formats: GeoParquet for analytical queries, PMTiles vector tiles for web maps, H3 hexagonal-grid parquet (hive-partitioned for fast spatial joins), and Cloud-Optimized GeoTIFFs. A single local CLI command generates Kubernetes Job manifests that orchestrate the entire conversion pipeline on a cluster, so large datasets are never processed on the local machine.",
+   "access_right":"open",
+   "license":"apache-2.0",
+   "upload_type":"software",
+   "grants":[
+      {
+         "id":"10.13039/100000001::2153040"
+      }
+   ]
+}

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # cng-datasets
 
+[![DOI](https://zenodo.org/badge/921944685.svg)](https://zenodo.org/badge/latestdoi/921944685)
+
 A CLI toolkit for processing large geospatial datasets into cloud-native formats on Kubernetes.
 
 **What it does:** Takes source geospatial data (Shapefiles, GeoPackages, FileGDB, GeoTIFFs) and produces:
@@ -170,3 +172,18 @@ pytest tests/
 ## License
 
 Apache 2.0
+
+## Citation
+
+If you use cng-datasets in your work, please cite it via its Zenodo archive.
+The DOI badge at the top of this README resolves to the latest release; each
+release also has its own version-specific DOI. Citation metadata (authors,
+title, funding) lives in [`.zenodo.json`](.zenodo.json) and is minted
+automatically by Zenodo on each GitHub release.
+
+> Boettiger, C., & Buhler, C. K. cng-datasets: A cloud-native toolkit for
+> processing large geospatial datasets on Kubernetes. Zenodo.
+> https://zenodo.org/badge/latestdoi/921944685
+
+Once the first release is archived on Zenodo, replace the redirect above with
+the concrete versioned DOI it mints.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ version = "0.2.0"
 description = "Cloud-native geospatial dataset processing toolkit"
 readme = "README.md"
 requires-python = ">=3.10"
-license = {text = "MIT"}
+license = {text = "Apache-2.0"}
 authors = [
     {name = "Boettiger Lab", email = "cboettig@berkeley.edu"}
 ]


### PR DESCRIPTION
## Summary

Adds a standard Zenodo citation to this repo, mirroring the setup in [`boettiger-lab/geo-agent`](https://github.com/boettiger-lab/geo-agent).

- **`.zenodo.json`** — deposit metadata: creators (Carl Boettiger, Cassidy Kim Buhler, with ORCIDs/affiliations), title, description, `upload_type: software`, `access_right: open`, NSF grant `2153040`, and `license: apache-2.0`.
- **`README.md`** — DOI badge (self-resolving `zenodo.org/badge/latestdoi/921944685` redirect) and a `## Citation` section.
- **`.gitignore`** — `!.zenodo.json` exception, since the blanket `*.json` rule was excluding it.
- **`pyproject.toml`** — fix license `MIT` → `Apache-2.0` to match the actual `LICENSE` file and README.

## Notes

- No DOI is fabricated — none exists until the repo is first archived on Zenodo. The `latestdoi` redirect resolves automatically once that happens; the README notes to swap in the concrete versioned DOI at that point.
- Activating the badge/DOI still requires enabling the GitHub→Zenodo integration for the repo and cutting a release (same as geo-agent). This PR just lands the metadata.