### PR TITLE
ci: add PyPI release via trusted publishing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,47 @@
+name: release
+
+on:
+  release:
+    types: [published]
+  pull_request:
+    branches: "*"
+
+permissions:
+  contents: read
+
+jobs:
+  build:
+    name: Build
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10  # v6
+      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405  # v6
+        with:
+          python-version: "3.12"
+      - name: Build sdist + wheel
+        run: |
+          python -m pip install build
+          python -m build
+      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: dist
+          path: dist/
+
+  publish:
+    name: Upload to PyPI
+    if: github.event_name == 'release'
+    needs: build
+    runs-on: ubuntu-latest
+    environment:
+      name: pypi
+      url: https://pypi.org/p/cng-datasets
+    permissions:
+      id-token: write
+    steps:
+      - name: Get dists artifact
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: dist
+          path: dist/
+      - name: Upload dists to PyPI
+        uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b # release/v1


### PR DESCRIPTION
## Summary

Adds a `release.yml` workflow so tagged releases publish `cng-datasets` to PyPI via **trusted publishing** (OIDC, no API tokens), matching [`SchmidtDSE/jupyter-sidekick`](https://github.com/SchmidtDSE/jupyter-sidekick/blob/main/.github/workflows/release.yml).

**Behavior:**
- On every **PR**: builds sdist + wheel (dry run — catches packaging breakage before release).
- On a **published GitHub Release**: rebuilds and uploads to PyPI via `pypa/gh-action-pypi-publish` using the `pypi` environment and `id-token: write`.

Differences from the sidekick reference: dropped the Node setup step (this is a pure-Python setuptools build); environment URL points at `https://pypi.org/p/cng-datasets`. Actions are SHA-pinned, consistent with the reference.

Verified `python -m build` produces a valid sdist + wheel locally (`cng_datasets-0.2.0`, Apache-2.0 metadata).

## Required one-time manual setup (outside this PR)

1. **PyPI → Manage `cng-datasets` → Publishing → add a trusted publisher:** owner `boettiger-lab`, repo `datasets`, workflow `release.yml`, environment `pypi`.
2. **GitHub → repo Settings → Environments → create `pypi`** (optionally with protection rules/required reviewers).
3. **Bump the version** in `pyproject.toml` before cutting a release — `0.2.0` is already on PyPI and PyPI rejects re-uploads of an existing version.

Follows #161 and #162.