### PR TITLE
release: 0.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.3.0] - 2026-07-20
+
+First release published to PyPI (`pip install cng-datasets`) via trusted publishing.
+
 ### Fixed
 - Vector H3 hex now splits circumpolar / transmeridian polygons (longitude-bbox span > 180°) into sub-180° longitude bands before polyfill, so they fill their full band instead of collapsing to ~1 cell. H3 `polygon_to_cells` reads a >180° ring as the minimal-area (complement) side; a full −180..180 band (e.g. CCAMLR's Southern-Ocean RFB) previously produced ~1 cell instead of millions. Narrow (<180°-span) polygons keep the original fast path unchanged (#145)
 - `workflow` now `shlex.quote`s each `--source-url` when interpolating it into the generated convert command, so URLs carrying `&` query strings (common for ArcGIS Hub / REST download endpoints) no longer break the `bash -c` step apart into background jobs (#147)
@@ -112,4 +116,5 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Resolution override behavior with helpful messages
 - Memory efficiency for large polygon processing
 
+[0.3.0]: https://github.com/boettiger-lab/datasets/releases/tag/v0.3.0
 [0.1.0]: https://github.com/boettiger-lab/datasets/releases/tag/v0.1.0

--- a/cng_datasets/__init__.py
+++ b/cng_datasets/__init__.py
@@ -5,7 +5,7 @@ A toolkit for processing large geospatial datasets into cloud-native formats
 (COG, GeoParquet, PMTiles) with H3 hexagonal indexing.
 """
 
-__version__ = "0.2.0"
+__version__ = "0.3.0"
 
 # Lazy imports can be handled by users as needed,
 # or we can keep these commented out to allow core usage without all dependencies.

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -13,7 +13,7 @@ sys.path.insert(0, os.path.abspath('..'))
 project = 'CNG Datasets'
 copyright = '2026, Boettiger Lab'
 author = 'Boettiger Lab'
-release = '0.2.0'
+release = '0.3.0'
 
 # -- General configuration ---------------------------------------------------
 # https://www.sphinx-doc.org/en/master/usage/configuration.html#general-configuration

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "cng-datasets"
-version = "0.2.0"
+version = "0.3.0"
 description = "Cloud-native geospatial dataset processing toolkit"
 readme = "README.md"
 requires-python = ">=3.10"


### PR DESCRIPTION
## Summary

Version bump for the **first PyPI release** of `cng-datasets` (0.3.0) via the trusted-publishing workflow added in #163.

- Bumps version to `0.3.0` in `pyproject.toml`, `cng_datasets/__init__.py`, and `docs/conf.py`.
- Rolls the `[Unreleased]` changelog entries into a dated `[0.3.0]` section:
  - `--resolution-by-area` variable-resolution H3 tiling (#98)
  - circumpolar / transmeridian polygon hex fix (#145)
  - `shlex.quote` on `--source-url` (#147)

Minor bump (not patch) because #98 adds a new feature. `cng-datasets` is not yet on PyPI, so 0.3.0 is the first published version.

Verified `python -m build` produces valid `cng_datasets-0.3.0` sdist + wheel locally.

After merge I'll tag & publish the `v0.3.0` GitHub Release, which triggers the trusted-publishing upload to PyPI.