### PR TITLE
Fix .zenodo.json so DOI minting succeeds (drop unresolvable grant)

### DIFF
--- a/.zenodo.json
+++ b/.zenodo.json
@@ -15,10 +15,5 @@
    "description":"A CLI toolkit that turns source geospatial data (Shapefiles, GeoPackages, FileGDB, GeoTIFFs) into cloud-native formats: GeoParquet for analytical queries, PMTiles vector tiles for web maps, H3 hexagonal-grid parquet (hive-partitioned for fast spatial joins), and Cloud-Optimized GeoTIFFs. A single local CLI command generates Kubernetes Job manifests that orchestrate the entire conversion pipeline on a cluster, so large datasets are never processed on the local machine.",
    "access_right":"open",
    "license":"apache-2.0",
-   "upload_type":"software",
-   "grants":[
-      {
-         "id":"10.13039/100000001::2153040"
-      }
-   ]
+   "upload_type":"software"
 }


### PR DESCRIPTION
Minting a Zenodo DOI on release currently fails with **HTTP 400**.

**Cause:** the `grants` block references an NSF award (`10.13039/100000001::2153040`). Zenodo validates each grant against the funder's award registry (via OpenAIRE); NSF award numbers are frequently absent, and an unresolvable grant rejects the whole deposit.

**Fix:** remove the `grants` block. Funding can be re-attached later interactively in the Zenodo web UI, which validates as you go. `license: "apache-2.0"` is unchanged and already matches the repo LICENSE.

Only `.zenodo.json` is touched (unrelated local `uv.lock`/`bench.py` changes are not included). Verified the file still parses as valid JSON.