### PR TITLE
release: 0.3.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.3.1] - 2026-07-21
+
+### Fixed
+- `.zenodo.json` dropped an unresolvable NSF grant identifier that caused Zenodo DOI minting to fail on the 0.3.0 release; the archive/DOI can now be minted (#165)
+
 ## [0.3.0] - 2026-07-20
 
 First release published to PyPI (`pip install cng-datasets`) via trusted publishing.

--- a/cng_datasets/__init__.py
+++ b/cng_datasets/__init__.py
@@ -5,7 +5,7 @@ A toolkit for processing large geospatial datasets into cloud-native formats
 (COG, GeoParquet, PMTiles) with H3 hexagonal indexing.
 """
 
-__version__ = "0.3.0"
+__version__ = "0.3.1"
 
 # Lazy imports can be handled by users as needed,
 # or we can keep these commented out to allow core usage without all dependencies.

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -13,7 +13,7 @@ sys.path.insert(0, os.path.abspath('..'))
 project = 'CNG Datasets'
 copyright = '2026, Boettiger Lab'
 author = 'Boettiger Lab'
-release = '0.3.0'
+release = '0.3.1'
 
 # -- General configuration ---------------------------------------------------
 # https://www.sphinx-doc.org/en/master/usage/configuration.html#general-configuration

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "cng-datasets"
-version = "0.3.0"
+version = "0.3.1"
 description = "Cloud-native geospatial dataset processing toolkit"
 readme = "README.md"
 requires-python = ">=3.10"


### PR DESCRIPTION
Patch release bumping version to 0.3.1.

The only functional change since 0.3.0 is the `.zenodo.json` fix (#165) — dropping the unresolvable NSF grant identifier that blocked Zenodo DOI minting on the 0.3.0 release. Cutting this release should let Zenodo mint the DOI.

- Bump version in `pyproject.toml`, `cng_datasets/__init__.py`, `docs/conf.py`
- Add dated `0.3.1` changelog section