### PR TITLE
fix(vector): harden hex pipeline against three failure modes (#169, #171, #170)

### DIFF
--- a/cng_datasets/vector/h3_tiling.py
+++ b/cng_datasets/vector/h3_tiling.py
@@ -581,9 +581,35 @@ class H3VectorProcessor:
         configure_s3_credentials(self.con)
 
     def _find_geometry_column(self, table_name: str) -> str:
-        """Find the geometry column in the table."""
-        result = self.con.execute(f"SELECT * FROM {table_name} LIMIT 0").description
-        columns = [col[0] for col in result]
+        """Find the geometry column in the table.
+
+        Resolves the geometry column by DuckDB *type* first: a column whose type
+        is GEOMETRY is the geometry, regardless of its name. This keeps an
+        unrelated attribute column that merely happens to be named
+        ``GEOMETRY``/``SHAPE``/``GEOM`` (e.g. a DOUBLE carried over from a source
+        DBF, issue #171) from shadowing the real geometry column and aborting the
+        hex job with an ``ST_GeometryType(DOUBLE)`` binder error. Name matching is
+        used only as a fallback when no GEOMETRY-typed column exists (e.g. WKB
+        stored as BLOB).
+        """
+        schema = self.con.execute(f"DESCRIBE {table_name}").fetchall()
+        # DESCRIBE rows are (column_name, column_type, ...). Geometry columns are
+        # reported as GEOMETRY (optionally with a CRS annotation, e.g.
+        # "GEOMETRY('OGC:CRS84')"), so match on the type prefix.
+        geom_typed = [
+            row[0] for row in schema if str(row[1]).upper().startswith('GEOMETRY')
+        ]
+        if geom_typed:
+            # If several geometry-typed columns exist, prefer conventional names;
+            # otherwise take the first geometry-typed column.
+            by_upper = {col.upper(): col for col in geom_typed}
+            for name in ['GEOM', 'GEOMETRY', 'SHAPE']:
+                if name in by_upper:
+                    return by_upper[name]
+            return geom_typed[0]
+
+        # Fallback: no GEOMETRY-typed column (e.g. WKB blobs) — match by name.
+        columns = [row[0] for row in schema]
         for col in columns:
             if col.upper() in ['SHAPE', 'GEOMETRY', 'GEOM']:
                 return col
@@ -870,6 +896,38 @@ class H3VectorProcessor:
         # Use local /tmp for fast batch processing, then copy to final destination
         local_output = f"/tmp/h3_output_{chunk_id:06d}.parquet"
         final_output = f"{self.output_url.rstrip('/')}/chunk_{chunk_id:06d}.parquet"
+
+        # A chunk whose features all produced zero H3 cells — most commonly a
+        # contiguous block of null-geometry features (issue #169) — yields a
+        # zero-row intermediate. The per-batch loop below would then never create
+        # `local_output`, and the final COPY would abort with "No files found".
+        # Instead, write an empty partition with the correct output schema so the
+        # chunk completes cleanly (there is genuinely no data to hex). Selecting
+        # the unnest expression over the empty intermediate reproduces exactly the
+        # non-empty output schema with zero rows.
+        if total_rows == 0:
+            if self.resolution_by_area is not None:
+                empty_sql = f"""
+                    SELECT "{id_col}", native_res, {union_cols_str}
+                    FROM (
+                        SELECT "{id_col}", native_res, UNNEST(h3id) AS cell
+                        FROM read_parquet('{intermediate_file}')
+                    )
+                """
+            else:
+                empty_sql = f"""
+                    SELECT "{id_col}",
+                           UNNEST(h3id) AS {h3_col}{parent_cols_str}
+                    FROM read_parquet('{intermediate_file}')
+                """
+            print(f"  Writing empty output (0 hexable rows) to {final_output}...")
+            self.con.execute(f"""
+                COPY ({empty_sql})
+                TO '{final_output}'
+                (FORMAT PARQUET, COMPRESSION 'ZSTD', ROW_GROUP_SIZE 100000)
+            """)
+            print(f"  ✓ Pass 2 complete (empty): {final_output}")
+            return final_output
 
         for batch_id in range(num_batches):
             batch_offset = batch_id * self.intermediate_chunk_size

--- a/cng_datasets/vector/repartition.py
+++ b/cng_datasets/vector/repartition.py
@@ -134,6 +134,49 @@ def repartition_by_h0(
             f" INNER JOIN _source_attrs s ON c.\"{chunk_id_col}\" = s.\"{chunk_id_col}\""
             f" WHERE c.h0 = {{h0}}"
         )
+
+        # Completeness guard (issue #170): the k8s hex Job is an indexed Job of
+        # `max-completions` chunks of `chunk-size` rows, so it only ever covers
+        # the first `max-completions × chunk-size` features. When the generator
+        # could not count the source up front it falls back to a default cap
+        # (e.g. 200k), and every downstream presence check still passes even
+        # though features past the cap were silently never hexed — only a
+        # post-build COUNT(DISTINCT id) catches it. Assert here, at the pipeline's
+        # natural endpoint (we hold both the hex output and the source), that
+        # every source feature with a non-null geometry made it into the hex. A
+        # shortfall is fatal: it turns silent data loss into a failed run.
+        #
+        # Null-geometry features are excluded because they legitimately produce
+        # no H3 cell (issue #169). Set CNG_SKIP_COMPLETENESS_CHECK=1 to bypass
+        # (e.g. a build with known-degenerate geometries that drop to 0 cells).
+        if os.environ.get('CNG_SKIP_COMPLETENESS_CHECK') not in ('1', 'true', 'True'):
+            geom_filter = f' WHERE "{geom_col}" IS NOT NULL' if geom_col else ''
+            source_features = con.raw_sql(
+                f"SELECT COUNT(*) FROM read_parquet('{source_parquet}'){geom_filter}"
+            ).fetchone()[0]
+            hexed_features = con.raw_sql(
+                f'SELECT COUNT(DISTINCT "{chunk_id_col}")'
+                f" FROM read_parquet('{chunks_dir}/*.parquet')"
+            ).fetchone()[0]
+            geom_note = ' with non-null geometry' if geom_col else ''
+            print(
+                f'  Completeness check: {hexed_features:,} of {source_features:,} '
+                f'source features{geom_note} present in hex output'
+            )
+            if hexed_features < source_features:
+                missing = source_features - hexed_features
+                raise RuntimeError(
+                    f"Hex output is incomplete: {hexed_features:,} of "
+                    f"{source_features:,} source features{geom_note} were hexed "
+                    f"({missing:,} missing). The k8s hex Job covers only "
+                    f"`max-completions × chunk-size` features, so a source larger "
+                    f"than that cap is silently truncated (issue #170). Re-run the "
+                    f"hex step with a larger --max-completions (or --chunk-size) so "
+                    f"that max-completions × chunk-size >= {source_features:,}. If "
+                    f"the shortfall is instead genuinely-degenerate geometry that "
+                    f"produces 0 H3 cells, set CNG_SKIP_COMPLETENESS_CHECK=1 to "
+                    f"proceed. Chunks left in place at '{chunks_dir}' for inspection."
+                )
     else:
         print('No source parquet provided, proceeding without attribute join')
         join_sql = (

--- a/tests/test_vector.py
+++ b/tests/test_vector.py
@@ -931,6 +931,122 @@ class TestOversizedFeatureGuard:
             processor.con.close()
 
 
+class TestGeometryColumnResolution:
+    """Issue #171: an unrelated attribute column named GEOMETRY/SHAPE/GEOM (e.g.
+    a DOUBLE carried over from a source DBF) must not shadow the real geometry
+    column and abort the hex job with an ST_GeometryType(DOUBLE) binder error."""
+
+    @pytest.mark.timeout(30)
+    def test_junk_geometry_named_attribute_does_not_shadow_real_geom(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            con = setup_duckdb_connection()
+            test_parquet = f"{tmpdir}/test.parquet"
+            # A DOUBLE attribute literally named GEOMETRY sits *before* the real
+            # geometry column `geom`, exactly as reported in issue #171.
+            con.execute(f"""
+                CREATE TABLE test_data AS
+                SELECT
+                    i AS _cng_fid,
+                    3.14 AS "GEOMETRY",
+                    ST_GeomFromText('POLYGON((-122.5 37.7, -122.4 37.7, -122.4 37.8, -122.5 37.8, -122.5 37.7))') AS geom
+                FROM range(5) t(i)
+            """)
+            con.execute(f"COPY test_data TO '{test_parquet}' (FORMAT PARQUET)")
+            con.close()
+
+            os.environ['AWS_ACCESS_KEY_ID'] = ''
+            os.environ['AWS_SECRET_ACCESS_KEY'] = ''
+
+            processor = H3VectorProcessor(
+                input_url=test_parquet,
+                output_url=tmpdir,
+                h3_resolution=8,
+                parent_resolutions=[0],
+                chunk_size=5,
+            )
+
+            # The geometry column must resolve to the real GEOMETRY-typed column.
+            processor.con.execute(f"""
+                CREATE OR REPLACE VIEW source_table AS
+                SELECT * FROM read_parquet('{test_parquet}')
+            """)
+            assert processor._find_geometry_column('source_table') == 'geom'
+
+            # And the full chunk must hex successfully rather than crash.
+            output_file = processor.process_chunk(0)
+            assert output_file is not None
+            assert Path(output_file).exists()
+            n = processor.con.execute(
+                f"SELECT COUNT(*) FROM read_parquet('{output_file}')"
+            ).fetchone()[0]
+            assert n > 0
+            processor.con.close()
+
+
+class TestAllNullGeometryChunk:
+    """Issue #169: a chunk whose features are all null-geometry produces a
+    zero-row intermediate and must be written as an empty partition instead of
+    crashing the Pass-2 final COPY with 'No files found'."""
+
+    @pytest.mark.timeout(30)
+    def test_all_null_geometry_chunk_writes_empty_partition(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            con = setup_duckdb_connection()
+            test_parquet = f"{tmpdir}/mixed_null.parquet"
+            # A real geoparquet: features 0-4 have geometry, features 5-9 are
+            # null-geometry. The geom column keeps its GEOMETRY type (some rows are
+            # non-null), and with chunk_size=5 the second chunk (offset 5) is an
+            # all-null window — exactly the contiguous null block from issue #169.
+            con.execute(f"""
+                CREATE TABLE test_data AS
+                SELECT
+                    i AS _cng_fid,
+                    CASE WHEN i < 5
+                         THEN ST_GeomFromText('POLYGON((-122.5 37.7, -122.4 37.7, -122.4 37.8, -122.5 37.8, -122.5 37.7))')
+                         ELSE CAST(NULL AS GEOMETRY)
+                    END AS geom
+                FROM range(10) t(i)
+            """)
+            con.execute(f"COPY test_data TO '{test_parquet}' (FORMAT PARQUET)")
+            con.close()
+
+            os.environ['AWS_ACCESS_KEY_ID'] = ''
+            os.environ['AWS_SECRET_ACCESS_KEY'] = ''
+
+            processor = H3VectorProcessor(
+                input_url=test_parquet,
+                output_url=tmpdir,
+                h3_resolution=10,
+                parent_resolutions=[9, 8, 0],
+                chunk_size=5,
+                intermediate_chunk_size=10,
+            )
+
+            # Chunk 1 is all null-geometry: must complete (not raise) and write an
+            # empty, correctly-typed partition.
+            output_file = processor.process_chunk(1)
+            assert output_file is not None
+            assert Path(output_file).exists()
+
+            result = processor.con.execute(
+                f"SELECT * FROM read_parquet('{output_file}')"
+            ).fetchdf()
+            assert len(result) == 0
+            # Output schema is intact so repartition can still read the partition,
+            # and matches the non-empty chunk-0 output.
+            assert 'h10' in result.columns
+            assert 'h0' in result.columns
+
+            # The empty partition's schema must match a populated chunk's, so a
+            # later repartition read_parquet('chunks/*') unions them cleanly.
+            chunk0 = processor.process_chunk(0)
+            cols0 = processor.con.execute(
+                f"SELECT * FROM read_parquet('{chunk0}') LIMIT 0"
+            ).fetchdf().columns.tolist()
+            assert list(result.columns) == cols0
+            processor.con.close()
+
+
 class TestSwappedCoordinateDetection:
     """Test that swapped lat/lon coordinates are detected and raise an error."""
 
@@ -1383,6 +1499,127 @@ class TestRepartitionWithAttributeJoin:
                     output_dir=output_dir,
                     cleanup=False,
                 )
+
+
+class TestRepartitionCompletenessGuard:
+    """Issue #170: repartition must hard-fail when the hex output is missing
+    source features (silent truncation from an under-sized k8s indexed Job),
+    while tolerating null-geometry features that legitimately produce no cells."""
+
+    def _make_source(self, tmpdir, n=10, null_from=None):
+        """Source parquet of n features; features with fid >= null_from (if set)
+        get a NULL geometry."""
+        con = setup_duckdb_connection()
+        src = f"{tmpdir}/source.parquet"
+        null_pred = f"i >= {null_from}" if null_from is not None else "false"
+        con.execute(f"""
+            CREATE TABLE test_data AS
+            SELECT
+                i AS _cng_fid,
+                CASE WHEN {null_pred}
+                     THEN CAST(NULL AS GEOMETRY)
+                     ELSE ST_GeomFromText('POLYGON((-122.5 37.7, -122.4 37.7, -122.4 37.8, -122.5 37.8, -122.5 37.7))')
+                END AS geom
+            FROM range({n}) t(i)
+        """)
+        con.execute(f"COPY test_data TO '{src}' (FORMAT PARQUET)")
+        con.close()
+        return src
+
+    def _hex_chunks(self, src, chunks_dir, chunk_ids, chunk_size=5):
+        os.makedirs(chunks_dir, exist_ok=True)
+        processor = H3VectorProcessor(
+            input_url=src, output_url=chunks_dir,
+            h3_resolution=8, parent_resolutions=[0], chunk_size=chunk_size,
+        )
+        for cid in chunk_ids:
+            processor.process_chunk(cid)
+        processor.con.close()
+
+    @pytest.mark.timeout(30)
+    def test_truncated_hex_output_raises(self):
+        """Only the first chunk was hexed (5 of 10 features) → hard-fail."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            os.environ['AWS_ACCESS_KEY_ID'] = ''
+            os.environ['AWS_SECRET_ACCESS_KEY'] = ''
+            src = self._make_source(tmpdir, n=10)
+            chunks_dir = f"{tmpdir}/chunks"
+            self._hex_chunks(src, chunks_dir, chunk_ids=[0], chunk_size=5)
+
+            with pytest.raises(RuntimeError, match=r"incomplete: 5 of 10"):
+                repartition_by_h0(
+                    chunks_dir=chunks_dir,
+                    output_dir=f"{tmpdir}/output",
+                    source_parquet=src,
+                    cleanup=False,
+                )
+
+    @pytest.mark.timeout(30)
+    def test_complete_hex_output_passes(self):
+        """All chunks hexed (10 of 10 features) → repartition succeeds."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            os.environ['AWS_ACCESS_KEY_ID'] = ''
+            os.environ['AWS_SECRET_ACCESS_KEY'] = ''
+            src = self._make_source(tmpdir, n=10)
+            chunks_dir = f"{tmpdir}/chunks"
+            self._hex_chunks(src, chunks_dir, chunk_ids=[0, 1], chunk_size=5)
+
+            repartition_by_h0(
+                chunks_dir=chunks_dir,
+                output_dir=f"{tmpdir}/output",
+                source_parquet=src,
+                cleanup=False,
+            )
+            con = setup_duckdb_connection()
+            n = con.execute(
+                f"SELECT COUNT(DISTINCT _cng_fid) FROM read_parquet('{tmpdir}/output/**/*.parquet')"
+            ).fetchone()[0]
+            con.close()
+            assert n == 10
+
+    @pytest.mark.timeout(30)
+    def test_null_geometry_features_excluded_from_count(self):
+        """Features 5-9 are null-geometry (never hexable). Hexing only chunk 0
+        still covers all 5 non-null features → passes, not a false truncation."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            os.environ['AWS_ACCESS_KEY_ID'] = ''
+            os.environ['AWS_SECRET_ACCESS_KEY'] = ''
+            src = self._make_source(tmpdir, n=10, null_from=5)
+            chunks_dir = f"{tmpdir}/chunks"
+            # Hex both chunks; chunk 1 is all-null and writes an empty partition.
+            self._hex_chunks(src, chunks_dir, chunk_ids=[0, 1], chunk_size=5)
+
+            repartition_by_h0(
+                chunks_dir=chunks_dir,
+                output_dir=f"{tmpdir}/output",
+                source_parquet=src,
+                cleanup=False,
+            )
+            con = setup_duckdb_connection()
+            n = con.execute(
+                f"SELECT COUNT(DISTINCT _cng_fid) FROM read_parquet('{tmpdir}/output/**/*.parquet')"
+            ).fetchone()[0]
+            con.close()
+            assert n == 5  # only the non-null-geometry features
+
+    @pytest.mark.timeout(30)
+    def test_skip_env_var_bypasses_guard(self, monkeypatch):
+        """CNG_SKIP_COMPLETENESS_CHECK=1 lets a truncated build through."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            os.environ['AWS_ACCESS_KEY_ID'] = ''
+            os.environ['AWS_SECRET_ACCESS_KEY'] = ''
+            monkeypatch.setenv('CNG_SKIP_COMPLETENESS_CHECK', '1')
+            src = self._make_source(tmpdir, n=10)
+            chunks_dir = f"{tmpdir}/chunks"
+            self._hex_chunks(src, chunks_dir, chunk_ids=[0], chunk_size=5)
+
+            repartition_by_h0(
+                chunks_dir=chunks_dir,
+                output_dir=f"{tmpdir}/output",
+                source_parquet=src,
+                cleanup=False,
+            )  # must not raise
+            assert Path(f"{tmpdir}/output").exists()
 
 
 class TestParseResolutionByArea:


### PR DESCRIPTION
Fixes the three most recent open vector-hex bugs. Each fix ships with a regression test that fails on the prior code and passes now.

## #171 — attribute column named `GEOMETRY` shadows the real geometry
A non-geometry attribute column literally named `GEOMETRY`/`SHAPE`/`GEOM` (e.g. a `DOUBLE` carried over from a source DBF) was picked before the real `geom`, aborting the hex job with `ST_GeometryType(DOUBLE)` BinderException.

`_find_geometry_column` now resolves by DuckDB **type** first — a `GEOMETRY`-typed column wins regardless of name — falling back to name matching only when no typed geometry column exists (e.g. WKB blobs).

## #169 — all-null-geometry chunk crashes Pass-2 `COPY`
A chunk whose features are all null-geometry produced a zero-row intermediate, so the Pass-2 batch loop never created the local file and the final `COPY` aborted with `No files found`, failing the whole indexed Job.

A zero-row intermediate now writes an **empty partition with the correct output schema** and returns cleanly (there is genuinely no data to hex). A test confirms the empty partition's columns match a populated chunk's, so repartition unions them fine.

## #170 — silent truncation of large vector hex builds
The k8s hex Job is an indexed Job covering only `max-completions × chunk-size` features. When the generator can't count the source up front it falls back to a default cap (e.g. 200k); features past the cap were **silently never hexed**, yet every presence-based downstream check passed — only a post-build `COUNT(DISTINCT id)` caught it.

`repartition_by_h0` now **hard-fails** (chosen behavior) when distinct hexed features are fewer than source features with non-null geometry — reporting both counts and the deficit. This runs at the pipeline's natural endpoint, where the generated repartition job already passes `--source-parquet`, so it fires in the real k8s pipeline.
- Null-geometry features are excluded from the baseline (they legitimately produce no cell, per #169), so a legitimate null tail doesn't trip the guard.
- `CNG_SKIP_COMPLETENESS_CHECK=1` bypasses it for builds with known-degenerate geometries.

## Tests
`tests/test_vector.py` — 66 pass (added 6 tests across 3 new classes: `TestGeometryColumnResolution`, `TestAllNullGeometryChunk`, `TestRepartitionCompletenessGuard`). Pre-existing `test_k8s_workflows.py` failures are network-dependent and unrelated to this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)