### PR TITLE
fix(vector): fail fast on antimeridian-crossing polygons instead of hanging (#167)

### DIFF
--- a/cng_datasets/vector/h3_tiling.py
+++ b/cng_datasets/vector/h3_tiling.py
@@ -144,6 +144,12 @@ def _native_res_case_sql(bins: List[Tuple[Optional[float], int]], geom_expr: str
 _TRANSMERIDIAN_MAX_SPAN_DEG = 180
 _TRANSMERIDIAN_BANDS = [(-180, -90), (-90, 0), (0, 90), (90, 180)]
 
+# Square of the equatorial metres-per-degree, for converting a planar ST_Area
+# (deg²) to an approximate area in m². Over-estimates away from the equator
+# (longitude degrees shrink with latitude), which is the safe direction for the
+# oversized-feature guard below.
+_DEG2_TO_M2 = 111_320.0 ** 2
+
 
 def _transmeridian_split_sql(carry_cols: str, source: str) -> str:
     """SQL for a CTE body that splits >180-deg-longitude-span polygons into bands.
@@ -619,21 +625,39 @@ class H3VectorProcessor:
         """Fail fast if any feature in `chunk_table` would produce an H3 cell
         array exceeding the single-array size limit (issue #107).
 
-        Estimates per-feature cell count as spheroid area / average hex area at
-        the target resolution and raises a clear RuntimeError naming the worst
-        offender (id, area, estimated cells) if it exceeds
-        ``self.max_cells_per_feature``. This converts an otherwise-fatal C++
-        page-size assertion in the Pass-1 COPY into an actionable error.
+        Estimates per-feature cell count as area / average hex area at the target
+        resolution and raises a clear RuntimeError naming the worst offender (id,
+        area, estimated cells) if it exceeds ``self.max_cells_per_feature``. This
+        converts an otherwise-fatal C++ page-size assertion in the Pass-1 COPY
+        into an actionable error.
+
+        Area is measured geodesically (``ST_Area_Spheroid``) for the common case,
+        but PLANARLY for antimeridian-crossing features — those whose longitude
+        bbox spans more than 180° (issue #167). ``h3_polygon_wkt_to_cells``
+        polyfills the planar WKT, so a narrow strip that crosses ±180° reads as a
+        near-hemisphere cartesian fill and enumerates billions of cells, hanging
+        Pass 1 for hours. ``ST_Area_Spheroid`` measures the geodesic (short-way)
+        region instead — small, or even NaN for such a polygon — so it slips past
+        the guard. Estimating these features from planar area (what the polyfill
+        actually walks) catches the explosion up front; a clean multipolygon of
+        islands either side of the dateline has small planar area and still passes.
 
         In variable-resolution mode (issue #98) the estimate uses each feature's
         own native resolution — large features map to a coarser resolution and far
         fewer cells, the per-feature back-off that complements this guardrail — and
         the reported resolution is the worst offender's native res.
         """
+        # Planar area (deg² → m²) for antimeridian-crossing features, geodesic
+        # area otherwise. See the docstring for why the choice matters (#167).
+        area_expr = (
+            f"CASE WHEN ST_XMax(geom) - ST_XMin(geom) > {_TRANSMERIDIAN_MAX_SPAN_DEG} "
+            f"THEN ST_Area(geom) * {_DEG2_TO_M2} "
+            f"ELSE ST_Area_Spheroid(geom) END"
+        )
         if self.resolution_by_area is not None:
             native_res_case = _native_res_case_sql(self.resolution_by_area, "geom")
             est_cells_expr = (
-                f"ST_Area_Spheroid(geom) / "
+                f"({area_expr}) / "
                 f"h3_get_hexagon_area_avg({native_res_case}, 'm^2')"
             )
             res_select = f"{native_res_case} AS native_res"
@@ -641,15 +665,16 @@ class H3VectorProcessor:
             avg_hex_m2 = self.con.execute(
                 f"SELECT h3_get_hexagon_area_avg({self.h3_resolution}, 'm^2')"
             ).fetchone()[0]
-            est_cells_expr = f"ST_Area_Spheroid(geom) / {avg_hex_m2}"
+            est_cells_expr = f"({area_expr}) / {avg_hex_m2}"
             res_select = f"{self.h3_resolution} AS native_res"
 
         worst = self.con.execute(f"""
             SELECT
                 "{id_col}" AS fid,
-                ST_Area_Spheroid(geom) AS area_m2,
+                {area_expr} AS area_m2,
                 {est_cells_expr} AS est_cells,
-                {res_select}
+                {res_select},
+                ST_XMax(geom) - ST_XMin(geom) AS lon_span
             FROM chunk_table
             WHERE ST_GeometryType(geom) NOT IN ('POINT', 'MULTIPOINT')
             ORDER BY est_cells DESC
@@ -658,13 +683,23 @@ class H3VectorProcessor:
 
         if worst is None or worst[2] is None:
             return
-        fid, area_m2, est_cells, native_res = worst
+        fid, area_m2, est_cells, native_res, lon_span = worst
         if est_cells > self.max_cells_per_feature:
+            antimeridian_note = ""
+            if lon_span is not None and lon_span > _TRANSMERIDIAN_MAX_SPAN_DEG:
+                antimeridian_note = (
+                    f" Its longitude bbox spans {lon_span:.1f}°, so it crosses the "
+                    f"antimeridian (±180°): the planar H3 polyfill would enumerate "
+                    f"the whole span (a near-global cell set) and hang (issue #167). "
+                    f"Split the feature at ±180° upstream, or drop it from the hex "
+                    f"input if it is a dateline artifact."
+                )
             raise RuntimeError(
                 f"Chunk {chunk_id}: feature {id_col}={fid} is too large to hex at "
                 f"resolution {native_res} — estimated {int(est_cells):,} H3 "
                 f"cells ({area_m2 / 1e6:,.0f} km²) would exceed the per-feature "
-                f"cell-array limit ({self.max_cells_per_feature:,}). A single "
+                f"cell-array limit ({self.max_cells_per_feature:,})."
+                f"{antimeridian_note} A single "
                 f"feature's cells are written as one array value, which cannot "
                 f"exceed the ~268M-element (2GB) Arrow/parquet-page ceiling. "
                 f"Hex this feature at a coarser resolution (see #98 for adaptive "

--- a/tests/test_vector.py
+++ b/tests/test_vector.py
@@ -931,6 +931,67 @@ class TestOversizedFeatureGuard:
             processor.con.close()
 
 
+class TestAntimeridianCrossingFeature:
+    """Issue #167: a polygon whose ring crosses the antimeridian (lon bbox span
+    > 180°) polyfills its full planar cartesian span — a near-global cell set —
+    and hangs Pass 1 for hours. ST_Area_Spheroid sees only the geodesic
+    short-way strip (small, or NaN), so the #107 oversized guard misses it. The
+    guard now estimates such features from planar area and fails fast."""
+
+    def _processor(self, tmpdir, wkt, resolution=10):
+        con = setup_duckdb_connection()
+        src = f"{tmpdir}/s.parquet"
+        con.execute(
+            f"COPY (SELECT 1 AS _cng_fid, ST_GeomFromText('{wkt}') AS geom) "
+            f"TO '{src}' (FORMAT PARQUET)"
+        )
+        con.close()
+        os.environ['AWS_ACCESS_KEY_ID'] = ''
+        os.environ['AWS_SECRET_ACCESS_KEY'] = ''
+        return H3VectorProcessor(
+            input_url=src, output_url=tmpdir,
+            h3_resolution=resolution, parent_resolutions=[0], chunk_size=10,
+        )
+
+    @pytest.mark.timeout(30)
+    def test_crossing_ring_fails_fast_instead_of_hanging(self):
+        """A single ring spanning ~358° of longitude must raise immediately
+        (planar-area estimate) rather than enumerate billions of cells."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            processor = self._processor(
+                tmpdir, 'POLYGON((179 51,-179 51,-179 57,179 57,179 51))',
+                resolution=10,
+            )
+            with pytest.raises(RuntimeError, match=r"too large to hex"):
+                processor._process_pass1(0)
+            # And the message must point at the antimeridian, not just "big".
+            try:
+                processor._process_pass1(0)
+            except RuntimeError as e:
+                assert 'antimeridian' in str(e)
+                assert '#167' in str(e)
+            processor.con.close()
+
+    @pytest.mark.timeout(60)
+    def test_clean_island_multipolygon_still_passes(self):
+        """Separate small islands either side of the dateline have a >180° bbox
+        span but tiny planar area — they must NOT be rejected (no false positive)
+        and must polyfill to real cells."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            processor = self._processor(
+                tmpdir,
+                'MULTIPOLYGON(((179.8 51,179.9 51,179.9 51.1,179.8 51.1,179.8 51)),'
+                '((-179.9 55,-179.8 55,-179.8 55.1,-179.9 55.1,-179.9 55)))',
+                resolution=8,
+            )
+            out = processor._process_pass1(0)  # must not raise
+            total = processor.con.execute(
+                f"SELECT sum(len(h3id)) FROM read_parquet('{out}')"
+            ).fetchone()[0]
+            assert total is not None and total > 0
+            processor.con.close()
+
+
 class TestGeometryColumnResolution:
     """Issue #171: an unrelated attribute column named GEOMETRY/SHAPE/GEOM (e.g.
     a DOUBLE carried over from a source DBF) must not shadow the real geometry


### PR DESCRIPTION
Fixes #167.

## The bug
`cng-datasets vector` hangs **indefinitely in Pass 1** on a single polygon whose ring crosses the antimeridian (longitude bbox span ~359°, e.g. an Aleutians census block group). The polyfill never returns; the whole indexed Job stalls.

## Root cause
`h3_polygon_wkt_to_cells` polyfills the **planar WKT**, so a narrow strip that crosses ±180° is interpreted as a ~358°-wide cartesian rectangle spanning the globe → billions of cells → CPU-bound hang (low RAM, no progress — exactly as reported).

The existing `_assert_no_oversized_feature` guard (#107) should have caught an oversized feature, but it sizes features with `ST_Area_Spheroid`, which measures the **geodesic short-way** region. For a dateline-crossing polygon that area is tiny — in fact **`NaN`** for a self-wrapping ring — so `est_cells > limit` is `NaN > limit` = `False` and the feature slips straight through to the hang.

Reproduced directly:
| geometry | lon span | `ST_Area_Spheroid` | planar `ST_Area` | res-10 polyfill |
|---|---|---|---|---|
| single ring `((179,-179,-179,179))` | 358° | `NaN` | 2,148 deg² (~26M km²) | **hangs** (billions of cells) |
| clean island multipolygon | 360° | `NaN` | 45.8 deg² | completes (~37M cells) |

## The fix
`_assert_no_oversized_feature` now estimates cells from **planar area** (deg² → m², equatorial factor — over-estimating off-equator, the safe direction for a guard) for features whose longitude span exceeds 180°, i.e. exactly what the planar polyfill walks. The accurate geodesic estimate is kept for the common sub-180° case, so normal features are unaffected.

Result:
- **Crossing ring** → raises in ~0.01s (was: multi-hour hang) with a message that names the antimeridian and suggests splitting at ±180° upstream / dropping a dateline artifact.
- **Clean island multipolygon** (>180° bbox but small planar area) → still hexes normally (no false positive).
- **#145 circumpolar full-band** polygons are unaffected (they go through `geom_to_h3_cells`, not this guard; a genuine full band at fine resolution is already correctly rejected by the pre-existing area check).

### Why fail-fast rather than auto-split
A fully-correct antimeridian split needs per-vertex longitude unwrapping (shift negative lons +360, split at 180, map back). DuckDB spatial exposes no `ST_ShiftLongitude`/per-vertex primitive, and a wide cartesian polygon's interior genuinely fills the middle, so intersection-based decomposition can't recover the narrow strip. Converting an unbounded hang into an immediate, actionable error (consistent with the #107 guard) unblocks the pipeline now; correct auto-splitting can follow if an unwrap primitive becomes available.

### Secondary observation in the issue
The "single-feature `--chunk-size 1` Pass 2: No such file" note does **not** reproduce on current `main` (a 1-feature chunk hexes fine — verified), so it's not addressed here.

## Tests
`tests/test_vector.py::TestAntimeridianCrossingFeature` — crossing ring fails fast with the antimeridian message; clean island multipolygon still passes. Full vector suite: 68 pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)