### PR TITLE
fix(workflow): right-size hex completions to chunk count (#144)

### DIFF
--- a/cng_datasets/k8s/workflows.py
+++ b/cng_datasets/k8s/workflows.py
@@ -417,23 +417,48 @@ _DEFAULT_H3_RESOLUTION = {
 }
 
 
-def _calculate_chunking(total_rows: int, max_completions: int = 200, max_parallelism: int = 50) -> tuple[int, int, int]:
+# Target number of features per hex chunk. chunk_size is floored at this value
+# so a small dataset is not shredded into ~max_completions tiny chunks (issue
+# #144): every k8s completion pulls the multi-GB image and claims a
+# namespace-quota slot, so over-provisioning a 6-chunk job to 200 pods is pure
+# waste (and blocks other jobs on a shared quota). Larger datasets still shrink
+# chunk_size above this floor to keep completions within max_completions. 1000
+# matches the effective chunk_size the previous formula already produced at the
+# 200k-feature scale, so per-pod memory/time is unchanged for large builds.
+_DEFAULT_TARGET_CHUNK_SIZE = 1000
+
+
+def _calculate_chunking(
+    total_rows: int,
+    max_completions: int = 200,
+    max_parallelism: int = 50,
+    target_chunk_size: int = _DEFAULT_TARGET_CHUNK_SIZE,
+) -> tuple[int, int, int]:
     """
     Calculate optimal chunk size, completions, and parallelism.
+
+    chunk_size is the target (default 1000) unless the dataset is large enough
+    that hitting it would need more than ``max_completions`` chunks, in which
+    case chunk_size grows so completions caps at ``max_completions``. This
+    right-sizes ``completions`` to the chunks that actually hold data instead of
+    always provisioning up to ``max_completions`` pods (issue #144).
 
     Args:
         total_rows: Total number of rows/features in dataset
         max_completions: Maximum number of job completions (default: 200)
         max_parallelism: Maximum parallelism (default: 50)
+        target_chunk_size: Preferred features per chunk / floor for chunk_size
 
     Returns:
         Tuple of (chunk_size, completions, parallelism)
     """
-    # Calculate chunk size to stay under max_completions
-    chunk_size = math.ceil(total_rows / max_completions)
+    # Floor chunk_size at the target; grow it only when the dataset would
+    # otherwise exceed max_completions chunks.
+    chunk_size = max(target_chunk_size, math.ceil(total_rows / max_completions))
 
-    # Calculate actual number of completions needed
-    completions = math.ceil(total_rows / chunk_size)
+    # Actual number of completions needed (at least 1, so the job is never
+    # generated with completions=0 for an empty/near-empty count).
+    completions = max(1, math.ceil(total_rows / chunk_size))
 
     # Set parallelism to min of max_parallelism or completions
     parallelism = min(max_parallelism, completions)

--- a/tests/test_armada.py
+++ b/tests/test_armada.py
@@ -268,13 +268,19 @@ class TestConvertWorkflowToArmada:
                 assert len(spec["jobs"]) >= 1
 
     @pytest.mark.timeout(30)
-    def test_hex_job_expanded_to_multiple_armada_jobs(self):
+    def test_hex_job_expanded_to_multiple_armada_jobs(self, monkeypatch):
+        # Pin the feature count so this exercises multi-completion expansion
+        # independently of the fixture's actual size and of the chunk-sizing
+        # policy (issue #144): 5000 features / 1000-per-chunk target -> 5 chunks.
+        import cng_datasets.k8s.workflows as wf
+        monkeypatch.setattr(wf, "_count_source_features", lambda *a, **k: 5000)
         with tempfile.TemporaryDirectory() as tmpdir:
             generate_dataset_workflow(
                 dataset_name="test-ds",
                 source_url="https://s3-west.nrp-nautilus.io/public-test/fixtures/test-fixture.gpkg",
                 bucket="test-bucket",
                 output_dir=tmpdir,
+                h3_resolution=10,  # skip network geometry-type detection
             )
 
             convert_workflow_to_armada(
@@ -289,7 +295,7 @@ class TestConvertWorkflowToArmada:
             with open(hex_armada) as f:
                 spec = yaml.safe_load(f)
 
-            # 5-feature fixture -> 5 completions -> 5 Armada jobs
+            # 5000 features -> 5 completions -> 5 Armada jobs
             assert len(spec["jobs"]) == 5
 
             # No JOB_COMPLETION_INDEX references should remain

--- a/tests/test_k8s_workflows.py
+++ b/tests/test_k8s_workflows.py
@@ -174,9 +174,10 @@ class TestWorkflowGeneration:
                 job = yaml.safe_load(f)
                 
             assert job["metadata"]["name"] == "test-ds-hex"
-            # 5-feature fixture -> chunk_size=1, completions=5, parallelism=5
-            assert job["spec"]["completions"] == 5
-            assert job["spec"]["parallelism"] == 5
+            # 5-feature fixture -> chunk_size floored at 1000 -> 1 chunk (#144),
+            # not 5 tiny one-feature pods.
+            assert job["spec"]["completions"] == 1
+            assert job["spec"]["parallelism"] == 1
             assert job["spec"]["completionMode"] == "Indexed"
     
     @pytest.mark.timeout(30)
@@ -229,15 +230,15 @@ class TestWorkflowGeneration:
                 job = yaml.safe_load(f)
                 
             assert job["metadata"]["name"] == "mappinginequality-hex"
-            # 5-feature fixture -> chunk_size=1, completions=5, parallelism=5
-            assert job["spec"]["completions"] == 5
-            assert job["spec"]["parallelism"] == 5
+            # 5-feature fixture -> chunk_size floored at 1000 -> 1 chunk (#144).
+            assert job["spec"]["completions"] == 1
+            assert job["spec"]["parallelism"] == 1
             assert job["spec"]["completionMode"] == "Indexed"
 
             # Check chunk-size is set correctly
             command = job["spec"]["template"]["spec"]["containers"][0]["command"]
             command_str = str(command)
-            assert "--chunk-size 1" in command_str
+            assert "--chunk-size 1000" in command_str
 
     @pytest.mark.timeout(5)
     def test_pmtiles_job_memory(self):
@@ -446,6 +447,54 @@ class TestWorkflowGeneration:
             # DuckDB limit should be 85% = 54GiB
             command = job["spec"]["template"]["spec"]["containers"][0]["command"][2]
             assert "--memory-limit 54GiB" in command
+
+
+class TestCalculateChunking:
+    """Issue #144: right-size hex `completions` to the chunks that hold data
+    instead of shredding small datasets into ~max_completions tiny pods."""
+
+    def test_small_dataset_uses_few_chunks(self):
+        """5,697 features -> 6 chunks of 1000, not ~200 tiny pods (the #144 repro)."""
+        from cng_datasets.k8s.workflows import _calculate_chunking
+        chunk_size, completions, parallelism = _calculate_chunking(5697, max_completions=200)
+        assert chunk_size == 1000
+        assert completions == 6
+        assert parallelism == 6
+
+    def test_tiny_dataset_is_single_chunk(self):
+        """A handful of features -> one pod, not one pod per feature."""
+        from cng_datasets.k8s.workflows import _calculate_chunking
+        assert _calculate_chunking(5, max_completions=200) == (1000, 1, 1)
+
+    def test_large_dataset_caps_at_max_completions(self):
+        """Beyond max_completions*target, chunk_size grows to cap completions."""
+        from cng_datasets.k8s.workflows import _calculate_chunking
+        # 711,583 features: target-1000 would need 712 > 200 chunks, so chunk_size
+        # grows to ceil(711583/200)=3558, completions caps at 200.
+        chunk_size, completions, parallelism = _calculate_chunking(711583, max_completions=200)
+        assert chunk_size == 3558
+        assert completions == 200
+        assert parallelism == 50
+        # Crucially, completions*chunk_size still covers every feature (no #170 truncation).
+        assert completions * chunk_size >= 711583
+
+    def test_boundary_at_target_times_max_completions(self):
+        """Exactly max_completions*target features stays at the target chunk size."""
+        from cng_datasets.k8s.workflows import _calculate_chunking
+        assert _calculate_chunking(200000, max_completions=200) == (1000, 200, 50)
+        # One more feature tips chunk_size up so completions stays <= max.
+        chunk_size, completions, _ = _calculate_chunking(200001, max_completions=200)
+        assert completions <= 200
+        assert chunk_size * completions >= 200001
+
+    def test_covers_all_features_across_scales(self):
+        """completions*chunk_size must always cover the dataset (no silent drop)."""
+        from cng_datasets.k8s.workflows import _calculate_chunking
+        for n in (1, 5, 999, 1000, 1001, 5697, 199999, 200000, 200001, 1_000_000):
+            chunk_size, completions, parallelism = _calculate_chunking(n, max_completions=200)
+            assert completions >= 1
+            assert completions <= 200
+            assert chunk_size * completions >= n, f"n={n} not fully covered"
 
 
 class TestEdgeCases:


### PR DESCRIPTION
Fixes #144.

## The problem
`_calculate_chunking` set `chunk_size = ceil(total_rows / max_completions)`, which drives `chunk_size` **down** to spread work across up to `max_completions` chunks. For a small dataset that shreds it into ~200 tiny chunks — each a k8s completion that pulls the multi-GB image, reads the parquet, processes a handful of features, and exits, while claiming a namespace-quota slot on a shared cluster.

**#144 repro (5,697 features):** old formula → `chunk_size 29`, `completions 197` (~200 pods for a job that needs 6).

## The fix
Floor `chunk_size` at a target (default **1000**):

```python
chunk_size  = max(target_chunk_size, ceil(total_rows / max_completions))
completions = max(1, ceil(total_rows / chunk_size))
parallelism = min(max_parallelism, completions)
```

- **Small/medium** datasets use `ceil(total_rows / 1000)` chunks: **5,697 → 6 completions / parallelism 6 / chunk-size 1000** (verified end-to-end from the generated hex YAML).
- **Large** datasets still cap at `max_completions`: the floor only binds until `total_rows > max_completions × target`, after which `chunk_size` grows (711,583 → chunk_size 3558, completions 200, parallelism 50).
- **1000 is not a new magic number** — it's the effective `chunk_size` the old formula already produced at the 200k-feature scale, so per-pod memory/time is unchanged for large builds.
- **No truncation:** `completions × chunk_size ≥ total_rows` holds at every scale (unit-tested), so this composes cleanly with the #170 completeness guard.
- The `--max-completions` "increase to reduce chunk size" escape hatch still works where it matters (large datasets, where `chunk_size` sits above the floor).

## Tests
`TestCalculateChunking` (network-free unit tests): small-dataset right-sizing, tiny→single chunk, large-dataset cap, the target×max boundary, and full-coverage across scales. Updated the two 5-feature-fixture assertions (now 1 chunk of 1000 instead of 5 one-feature pods). Offline suite green (73 passed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)