### PR TITLE
feat(pmtiles): read tile-accurate table:columns from the PMTiles footer (#140)

### DIFF
--- a/DATASET_DOCUMENTATION_WORKFLOW.md
+++ b/DATASET_DOCUMENTATION_WORKFLOW.md
@@ -20,7 +20,20 @@ For Parquet files, use DuckDB to inspect the schema and understand the columns/f
 duckdb -c "INSTALL httpfs; LOAD httpfs; DESCRIBE SELECT * FROM 'https://s3-west.nrp-nautilus.io/public-<dataset>/<file>.parquet' LIMIT 1;"
 ```
 
-For PMTiles, you can inspect the metadata using `pmtiles` CLI or by creating a temporary inspection script.
+For PMTiles, get the **tile-accurate** field list — tippecanoe writes only a
+subset of the source columns into the tiles, so the PMTiles schema differs from
+the Parquet schema. Read it straight from the archive footer (works on a local
+path, `http(s)://`, or `s3://` — only the header + metadata blob are fetched):
+
+```bash
+# Ready-to-paste STAC table:columns (name + type) for what's actually in the tiles
+cng-datasets pmtiles-columns https://s3-west.nrp-nautilus.io/public-<dataset>/<file>.pmtiles
+# Full PMTiles metadata (vector_layers, zoom range, ...)
+cng-datasets pmtiles-columns <file>.pmtiles --full-metadata
+```
+
+Use this field list for the PMTiles asset's `table:columns` in step 4B so it
+reflects the tiles, not the (superset) Parquet schema (issue #140).
 
 ## 3. Research Metadata & Citations
 

--- a/cng_datasets/cli.py
+++ b/cng_datasets/cli.py
@@ -211,6 +211,15 @@ def main():
     setup_bucket_parser.add_argument("--no-cors", action="store_true", help="Skip CORS configuration")
     setup_bucket_parser.add_argument("--verify", action="store_true", help="Verify bucket configuration after setup")
 
+    # PMTiles tile-accurate column inspection (issue #140)
+    pmtiles_cols_parser = subparsers.add_parser(
+        "pmtiles-columns",
+        help="Read tile-accurate STAC table:columns from a PMTiles footer")
+    pmtiles_cols_parser.add_argument("source", help="Path / http(s):// / s3:// to a .pmtiles archive")
+    pmtiles_cols_parser.add_argument("--layer", default=None, help="Restrict to a single vector layer id")
+    pmtiles_cols_parser.add_argument("--full-metadata", action="store_true",
+                                     help="Print the full PMTiles metadata JSON instead of table:columns")
+
     args = parser.parse_args()
 
     if not args.command:
@@ -459,6 +468,14 @@ def _dispatch(args):
                 print(json.dumps(results, indent=2))
 
             sys.exit(0 if success else 1)
+
+    elif args.command == "pmtiles-columns":
+        from .vector.pmtiles import read_pmtiles_metadata, pmtiles_table_columns
+        import json
+        if args.full_metadata:
+            print(json.dumps(read_pmtiles_metadata(args.source), indent=2))
+        else:
+            print(json.dumps(pmtiles_table_columns(args.source, layer=args.layer), indent=2))
 
 
 if __name__ == "__main__":

--- a/cng_datasets/vector/pmtiles.py
+++ b/cng_datasets/vector/pmtiles.py
@@ -18,7 +18,7 @@ internal-compression code at byte 97 (1 = none, 2 = gzip — what tippecanoe use
 import gzip
 import json
 import struct
-from typing import Dict, List, Optional, Union
+from typing import Dict, List, Optional
 from urllib.request import Request, urlopen
 
 

--- a/cng_datasets/vector/pmtiles.py
+++ b/cng_datasets/vector/pmtiles.py
@@ -1,0 +1,138 @@
+"""
+Read tile-accurate field metadata from a PMTiles archive footer.
+
+tippecanoe writes only a *subset* of the source columns into the vector tiles
+(after any ``-y``/``-x`` includes, drop-densest, and attribute coercion), so the
+PMTiles schema differs from the source GeoParquet schema. The authoritative tile
+schema is ``vector_layers[].fields`` in the PMTiles metadata blob. This module
+reads that blob from the archive footer — locally or over an HTTP/S3 byte range,
+without downloading the whole tileset — and maps the tippecanoe field types to
+STAC ``table:columns`` entries, so a STAC collection can advertise the fields
+that are actually present in the tiles (issue #140).
+
+The header layout is the PMTiles v3 spec: a fixed 127-byte header with the
+metadata offset (uint64 LE at byte 24) and length (uint64 LE at byte 32), and the
+internal-compression code at byte 97 (1 = none, 2 = gzip — what tippecanoe uses).
+"""
+
+import gzip
+import json
+import struct
+from typing import Dict, List, Optional, Union
+from urllib.request import Request, urlopen
+
+
+_PMTILES_HEADER_LEN = 127
+_METADATA_OFFSET_POS = 24   # uint64 LE
+_METADATA_LENGTH_POS = 32   # uint64 LE
+_INTERNAL_COMPRESSION_POS = 97  # 1=none, 2=gzip, 3=brotli, 4=zstd
+
+# tippecanoe emits these three field types in vector_layers[].fields; map each to
+# the STAC table:columns / frictionless type vocabulary.
+_TIPPECANOE_TYPE_TO_STAC = {
+    "String": "string",
+    "Number": "number",
+    "Boolean": "boolean",
+}
+
+
+def _is_remote(source: str) -> bool:
+    return source.startswith(("http://", "https://", "s3://"))
+
+
+def _to_https(source: str) -> str:
+    """Rewrite an s3:// NRP path to its public HTTPS endpoint (byte-range capable)."""
+    if source.startswith("s3://"):
+        return f"https://s3-west.nrp-nautilus.io/{source[len('s3://'):]}"
+    return source
+
+
+def _read_range(source: str, start: int, length: int) -> bytes:
+    """Read ``length`` bytes starting at ``start`` from a local path or remote URL.
+
+    Remote reads use an HTTP Range request so only the header and metadata blob
+    are fetched, never the (potentially multi-GB) tile body.
+    """
+    if _is_remote(source):
+        url = _to_https(source)
+        req = Request(url, headers={"Range": f"bytes={start}-{start + length - 1}"})
+        with urlopen(req) as resp:
+            return resp.read()
+    with open(source, "rb") as f:
+        f.seek(start)
+        return f.read(length)
+
+
+def read_pmtiles_metadata(source: str) -> dict:
+    """Read and decode the PMTiles metadata JSON from ``source``'s footer.
+
+    Args:
+        source: Local path, ``http(s)://`` URL, or ``s3://`` NRP path to a
+            ``.pmtiles`` archive.
+
+    Returns:
+        The parsed metadata object (includes ``vector_layers`` for vector tiles).
+
+    Raises:
+        ValueError: not a PMTiles v3 archive, or an internal compression this
+            reader does not support (only none/gzip — what tippecanoe writes).
+    """
+    header = _read_range(source, 0, _PMTILES_HEADER_LEN)
+    if header[:7] != b"PMTiles":
+        raise ValueError(f"{source!r} is not a PMTiles archive (bad magic).")
+    version = header[7]
+    if version != 3:
+        raise ValueError(f"{source!r} is PMTiles v{version}; only v3 is supported.")
+
+    metadata_offset = struct.unpack_from("<Q", header, _METADATA_OFFSET_POS)[0]
+    metadata_length = struct.unpack_from("<Q", header, _METADATA_LENGTH_POS)[0]
+    internal_compression = header[_INTERNAL_COMPRESSION_POS]
+
+    blob = _read_range(source, metadata_offset, metadata_length)
+    if internal_compression == 2:      # gzip (tippecanoe default)
+        blob = gzip.decompress(blob)
+    elif internal_compression == 1:    # none
+        pass
+    else:
+        raise ValueError(
+            f"{source!r} uses internal compression code {internal_compression} "
+            f"(brotli/zstd); only none(1) and gzip(2) are supported."
+        )
+    return json.loads(blob.decode("utf-8"))
+
+
+def pmtiles_vector_layers(source: str) -> List[dict]:
+    """Return the ``vector_layers`` array from a PMTiles archive's metadata.
+
+    Empty list for a non-vector (raster) archive.
+    """
+    meta = read_pmtiles_metadata(source)
+    return meta.get("vector_layers", []) or []
+
+
+def pmtiles_table_columns(source: str, layer: Optional[str] = None) -> List[Dict[str, str]]:
+    """Extract tile-accurate STAC ``table:columns`` entries from a PMTiles footer.
+
+    The tile fields (``vector_layers[].fields``) are the authoritative list of
+    what a consumer can style/filter in the tiles — a subset of the source
+    schema (issue #140). tippecanoe field types (String/Number/Boolean) are
+    mapped to STAC ``table:columns`` types (string/number/boolean); an unknown
+    type falls back to ``string``.
+
+    Args:
+        source: Local path / ``http(s)://`` / ``s3://`` to a ``.pmtiles`` archive.
+        layer: Restrict to a single vector layer id; default merges all layers.
+
+    Returns:
+        A list of ``{"name": <field>, "type": <stac-type>}`` dicts, de-duplicated
+        by field name (first occurrence wins), in first-seen order — ready to drop
+        into a STAC collection's ``table:columns``.
+    """
+    columns: Dict[str, str] = {}
+    for lyr in pmtiles_vector_layers(source):
+        if layer is not None and lyr.get("id") != layer:
+            continue
+        for name, ttype in (lyr.get("fields") or {}).items():
+            if name not in columns:
+                columns[name] = _TIPPECANOE_TYPE_TO_STAC.get(ttype, "string")
+    return [{"name": name, "type": stac_type} for name, stac_type in columns.items()]

--- a/tests/test_pmtiles.py
+++ b/tests/test_pmtiles.py
@@ -1,0 +1,145 @@
+"""Tests for reading tile-accurate field metadata from a PMTiles footer (#140)."""
+
+import gzip
+import json
+import struct
+import tempfile
+import os
+
+import pytest
+
+from cng_datasets.vector.pmtiles import (
+    read_pmtiles_metadata,
+    pmtiles_vector_layers,
+    pmtiles_table_columns,
+)
+
+
+def _make_pmtiles(metadata: dict, compression: int = 2, version: int = 3,
+                  magic: bytes = b"PMTiles") -> bytes:
+    """Build a minimal PMTiles v3 archive: 127-byte header + metadata blob.
+
+    compression: 1=none, 2=gzip (matches the internal-compression byte at 97).
+    """
+    raw = json.dumps(metadata).encode("utf-8")
+    blob = gzip.compress(raw) if compression == 2 else raw
+    header = bytearray(127)
+    header[0:7] = magic
+    header[7] = version
+    struct.pack_into("<Q", header, 24, 127)          # metadata offset
+    struct.pack_into("<Q", header, 32, len(blob))    # metadata length
+    header[97] = compression
+    return bytes(header) + blob
+
+
+def _write_tmp(data: bytes) -> str:
+    with tempfile.NamedTemporaryFile(suffix=".pmtiles", delete=False) as f:
+        f.write(data)
+        return f.name
+
+
+_SVI_META = {
+    "vector_layers": [
+        {"id": "svi", "fields": {
+            "COUNTY": "String", "FIPS": "String",
+            "RPL_THEMES": "Number", "FLAG": "Boolean",
+        }}
+    ]
+}
+
+
+class TestReadPmtilesMetadata:
+    def test_gzip_roundtrip(self):
+        path = _write_tmp(_make_pmtiles(_SVI_META, compression=2))
+        try:
+            assert read_pmtiles_metadata(path) == _SVI_META
+        finally:
+            os.unlink(path)
+
+    def test_uncompressed_metadata(self):
+        path = _write_tmp(_make_pmtiles(_SVI_META, compression=1))
+        try:
+            assert read_pmtiles_metadata(path) == _SVI_META
+        finally:
+            os.unlink(path)
+
+    def test_bad_magic_raises(self):
+        path = _write_tmp(_make_pmtiles(_SVI_META, magic=b"NOTPMT!"))
+        try:
+            with pytest.raises(ValueError, match="not a PMTiles archive"):
+                read_pmtiles_metadata(path)
+        finally:
+            os.unlink(path)
+
+    def test_unsupported_version_raises(self):
+        path = _write_tmp(_make_pmtiles(_SVI_META, version=2))
+        try:
+            with pytest.raises(ValueError, match="only v3 is supported"):
+                read_pmtiles_metadata(path)
+        finally:
+            os.unlink(path)
+
+    def test_unsupported_compression_raises(self):
+        path = _write_tmp(_make_pmtiles(_SVI_META, compression=3))  # brotli
+        try:
+            with pytest.raises(ValueError, match="only none.*and gzip"):
+                read_pmtiles_metadata(path)
+        finally:
+            os.unlink(path)
+
+
+class TestPmtilesTableColumns:
+    def test_type_mapping(self):
+        path = _write_tmp(_make_pmtiles(_SVI_META))
+        try:
+            cols = pmtiles_table_columns(path)
+            assert cols == [
+                {"name": "COUNTY", "type": "string"},
+                {"name": "FIPS", "type": "string"},
+                {"name": "RPL_THEMES", "type": "number"},
+                {"name": "FLAG", "type": "boolean"},
+            ]
+        finally:
+            os.unlink(path)
+
+    def test_unknown_type_falls_back_to_string(self):
+        meta = {"vector_layers": [{"id": "L", "fields": {"weird": "SomethingElse"}}]}
+        path = _write_tmp(_make_pmtiles(meta))
+        try:
+            assert pmtiles_table_columns(path) == [{"name": "weird", "type": "string"}]
+        finally:
+            os.unlink(path)
+
+    def test_multiple_layers_merged_and_deduped(self):
+        meta = {"vector_layers": [
+            {"id": "a", "fields": {"shared": "String", "only_a": "Number"}},
+            {"id": "b", "fields": {"shared": "Number", "only_b": "String"}},  # shared: first wins
+        ]}
+        path = _write_tmp(_make_pmtiles(meta))
+        try:
+            cols = pmtiles_table_columns(path)
+            names = [c["name"] for c in cols]
+            assert names == ["shared", "only_a", "only_b"]
+            # first occurrence (layer a, String) wins for the shared field
+            assert next(c for c in cols if c["name"] == "shared")["type"] == "string"
+        finally:
+            os.unlink(path)
+
+    def test_layer_filter(self):
+        meta = {"vector_layers": [
+            {"id": "a", "fields": {"fa": "String"}},
+            {"id": "b", "fields": {"fb": "Number"}},
+        ]}
+        path = _write_tmp(_make_pmtiles(meta))
+        try:
+            assert pmtiles_table_columns(path, layer="b") == [{"name": "fb", "type": "number"}]
+        finally:
+            os.unlink(path)
+
+    def test_raster_pmtiles_has_no_vector_layers(self):
+        path = _write_tmp(_make_pmtiles({"type": "raster"}))
+        try:
+            assert pmtiles_vector_layers(path) == []
+            assert pmtiles_table_columns(path) == []
+        finally:
+            os.unlink(path)


### PR DESCRIPTION
Fixes #140.

## Problem
tippecanoe writes only a *subset* of the source columns into the vector tiles, so the PMTiles schema differs from the source Parquet schema. STAC collections here author `table:columns` **by hand** (there is no automated STAC publisher in this repo — see `DATASET_DOCUMENTATION_WORKFLOW.md`), and the only way to know which fields actually survived into the tiles was to byte-range the `.pmtiles` footer with a throwaway script. Result: PMTiles assets ship with empty (or Parquet-superset, misleading) `table:columns`.

## What this adds
`cng_datasets/vector/pmtiles.py` — a stdlib-only footer reader (no runtime dep, no whole-file download):

- **`read_pmtiles_metadata(source)`** — parse the PMTiles v3 header (metadata offset uint64 LE @ byte 24, length @ 32, internal-compression @ 97), decompress (gzip/none), decode JSON. Works on a local path, `http(s)://`, or `s3://` via an HTTP **Range** request that fetches only the 127-byte header + the metadata blob, never the multi-GB tile body.
- **`pmtiles_vector_layers()` / `pmtiles_table_columns(source, layer=None)`** — extract `vector_layers[].fields` and map tippecanoe types (`String`/`Number`/`Boolean`) → STAC `table:columns` types (`string`/`number`/`boolean`; unknown → `string`), de-duplicated across layers (first wins), with an optional single-layer filter.

**CLI:** `cng-datasets pmtiles-columns <path|url|s3>` prints ready-to-paste `table:columns` (or `--full-metadata`). Referenced in Step 2 of `DATASET_DOCUMENTATION_WORKFLOW.md`, where the workflow already tells authors to inspect PMTiles metadata — so it plugs directly into the manual STAC authoring the repo actually does.

## Validation
Against the exact published artifact from the issue:
```
$ cng-datasets pmtiles-columns https://s3-west.nrp-nautilus.io/public-social-vulnerability/2022/SVI2022_US_tract.pmtiles
[{"name":"COUNTY","type":"string"},{"name":"FIPS","type":"string"},
 {"name":"RPL_THEMES","type":"number"},{"name":"ST_ABBR","type":"string"}]
```
— exactly the 4-of-~150 tile subset the issue documented, from layer `svi`.

## Tests
`tests/test_pmtiles.py` (10, network-free — synthetic v3 archives): gzip/uncompressed round-trip; bad-magic / wrong-version / unsupported-compression errors; type mapping; unknown-type fallback; multi-layer merge+dedup; layer filter; raster (no `vector_layers`).

## Scope note
This repo has no programmatic STAC publisher to auto-wire into (collections are authored per `DATASET_DOCUMENTATION_WORKFLOW.md`), so the deliverable is the reusable extractor + CLI the issue's "Suggested implementation" describes. If/when a publisher is added, it imports `pmtiles_table_columns()` directly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)