### PR TITLE
feat(convert): add opt-in --trim-strings to vector convert/workflow (#180)

### DIFF
--- a/cng_datasets/cli.py
+++ b/cng_datasets/cli.py
@@ -124,6 +124,7 @@ def main():
     workflow_parser.add_argument("--intermediate-chunk-size", type=int, default=10, help="Number of rows to process in pass 2 (unnesting arrays) - reduce if hitting OOM")
     workflow_parser.add_argument("--row-group-size", type=int, default=100000, help="Number of rows per group in convert job (default: 100000)")
     workflow_parser.add_argument("--simplify-tolerance", type=float, default=None, help="Simplify geometry to this tolerance in target-CRS units (degrees for EPSG:4326; e.g. 0.0001 ~ 10m) during the convert step. Right-sizes high-vertex sources for tiling/hex (issue #132).")
+    workflow_parser.add_argument("--trim-strings", action="store_true", help="Strip leading/trailing whitespace from every string column during the convert step. Off by default; opt in for sources whose categorical fields carry stray whitespace, which silently breaks equality filters (issue #180).")
     workflow_parser.add_argument("--hex-storage", type=str, default="10Gi", help="Ephemeral storage request/limit per hex job pod (default: 10Gi)")
     workflow_parser.add_argument("--repartition-storage", type=str, default="50Gi", help="Ephemeral storage request/limit for repartition job pod (default: 50Gi)")
     workflow_parser.add_argument("--repartition-memory", type=str, default="32Gi", help="Memory request/limit for repartition job pod (default: 32Gi)")
@@ -385,6 +386,7 @@ def _dispatch(args):
             intermediate_chunk_size=args.intermediate_chunk_size,
             row_group_size=args.row_group_size,
             simplify_tolerance=args.simplify_tolerance,
+            trim_strings=args.trim_strings,
             backend=args.backend,
             hex_storage=args.hex_storage,
             repartition_storage=args.repartition_storage,

--- a/cng_datasets/k8s/workflows.py
+++ b/cng_datasets/k8s/workflows.py
@@ -485,6 +485,7 @@ def generate_dataset_workflow(
     intermediate_chunk_size: int = 10,
     row_group_size: int = 100000,
     simplify_tolerance: Optional[float] = None,
+    trim_strings: bool = False,
     pmtiles_max_zoom: Optional[int] = None,
     backend: str = "k8s",
     hex_storage: str = "10Gi",
@@ -588,7 +589,7 @@ def generate_dataset_workflow(
     _generate_setup_bucket_job(manager, k8s_name, bucket, output_path, git_repo, config)
 
     # Generate conversion job
-    _generate_convert_job(manager, k8s_name, source_urls, bucket, output_path, git_repo, layer, memory=hex_memory, row_group_size=row_group_size, s3_dataset=dataset_name, config=config, simplify_tolerance=simplify_tolerance)
+    _generate_convert_job(manager, k8s_name, source_urls, bucket, output_path, git_repo, layer, memory=hex_memory, row_group_size=row_group_size, s3_dataset=dataset_name, config=config, simplify_tolerance=simplify_tolerance, trim_strings=trim_strings)
 
     # Generate pmtiles job (uses converted parquet, not source)
     _generate_pmtiles_job(manager, k8s_name, None, bucket, output_path, git_repo, memory=hex_memory, s3_dataset=dataset_name, config=config, h3_resolution=h3_resolution, max_zoom=pmtiles_max_zoom)
@@ -1224,7 +1225,7 @@ echo "Bucket setup complete!"
     manager.save_job_yaml(job_spec, str(output_path / f"{dataset_name}-setup-bucket.yaml"))
 
 
-def _generate_convert_job(manager, dataset_name, source_urls, bucket, output_path, git_repo, layer=None, memory="8Gi", row_group_size=100000, s3_dataset=None, config: ClusterConfig = None, simplify_tolerance=None):
+def _generate_convert_job(manager, dataset_name, source_urls, bucket, output_path, git_repo, layer=None, memory="8Gi", row_group_size=100000, s3_dataset=None, config: ClusterConfig = None, simplify_tolerance=None, trim_strings=False):
     """Generate GeoParquet conversion job."""
     if config is None:
         config = ClusterConfig()
@@ -1240,17 +1241,18 @@ def _generate_convert_job(manager, dataset_name, source_urls, bucket, output_pat
     # interpret as job control and split the command apart. See issue #147.
     sources_str = " \\\n  ".join(shlex.quote(url) for url in source_urls)
 
-    # Build the conversion command with optional layer / simplify parameters
+    # Build the conversion command with optional layer / simplify / trim parameters
     layer_flag = f" \\\n  --layer {layer}" if layer else ""
     simplify_flag = (
         f" \\\n  --simplify-tolerance {simplify_tolerance}"
         if simplify_tolerance is not None else ""
     )
+    trim_flag = " \\\n  --trim-strings" if trim_strings else ""
     convert_cmd = f"""set -e
 cng-convert-to-parquet \\
   {sources_str} \\
   s3://{bucket}/{s3_dataset}.parquet \\
-  --row-group-size {row_group_size}{layer_flag}{simplify_flag}
+  --row-group-size {row_group_size}{layer_flag}{simplify_flag}{trim_flag}
 """
 
     pod_spec = {

--- a/cng_datasets/vector/convert_to_parquet.py
+++ b/cng_datasets/vector/convert_to_parquet.py
@@ -580,10 +580,100 @@ def check_id_column(source_url: str, layer: Optional[str] = None, id_column: Opt
         con.close()
 
 
+# Characters stripped from both ends of every string column when --trim-strings
+# is set (issue #180). DuckDB's one-argument trim() removes ASCII spaces only, so
+# the character set is passed explicitly to also catch tabs and stray newlines
+# that GDB/Shapefile attribute values sometimes carry.
+_TRIM_CHARS = " \\t\\n\\r"
+
+
+def string_columns_from_describe(columns: List[tuple]) -> List[str]:
+    """
+    Pick the plain string columns out of a DuckDB DESCRIBE result.
+
+    Only top-level VARCHAR columns are returned: those are the categorical
+    attribute fields where stray leading/trailing whitespace silently breaks
+    equality filters (issue #180). Nested types (VARCHAR[], STRUCT) are left
+    alone — trimming inside them needs a different expression and no source has
+    called for it.
+
+    Args:
+        columns: Rows from `DESCRIBE SELECT ...` — (column_name, column_type, ...)
+
+    Returns:
+        Names of the VARCHAR columns, in source order
+    """
+    return [name for name, col_type, *_ in columns if col_type.upper() == 'VARCHAR']
+
+
+def get_string_columns(source_url: str, layer: Optional[str] = None,
+                       verbose: bool = False) -> List[str]:
+    """
+    List the VARCHAR columns of an ST_Read-able source (issue #180).
+
+    Args:
+        source_url: Source dataset URL/path (GDAL-readable)
+        layer: Layer name for multi-layer datasets (e.g. GDB)
+        verbose: Print debug information
+
+    Returns:
+        Names of the VARCHAR columns; empty list if detection fails (trimming is
+        an opt-in convenience, so a failed probe must not fail the conversion).
+    """
+    con = duckdb.connect(':memory:')
+    con.install_extension("spatial")
+    con.load_extension("spatial")
+    con.execute("SET arrow_large_buffer_size=true")
+
+    try:
+        layer_param = f", layer='{layer}'" if layer else ""
+        columns = con.execute(
+            f"DESCRIBE SELECT * FROM ST_Read('{source_url}'{layer_param}) LIMIT 0"
+        ).fetchall()
+        string_cols = string_columns_from_describe(columns)
+        if verbose:
+            print(f"  String columns: {string_cols}")
+        return string_cols
+    except Exception as e:
+        print(f"  Warning: could not detect string columns ({e}) — "
+              f"proceeding WITHOUT trimming")
+        return []
+    finally:
+        con.close()
+
+
+def trim_replace_clause(string_columns: Optional[List[str]],
+                        exclude: Optional[List[str]] = None) -> str:
+    """
+    Build a DuckDB `REPLACE (...)` clause that trims each string column in place.
+
+    Using star-REPLACE keeps the projection a one-liner per column and leaves
+    every other column (and the source column order) untouched, so it composes
+    with `* EXCLUDE (geom)` and the synthetic `_cng_fid` wrapper.
+
+    Args:
+        string_columns: VARCHAR column names to trim (None/empty -> no clause)
+        exclude: Column names to skip (e.g. a geometry column already excluded
+            from the star, which REPLACE cannot refer to)
+
+    Returns:
+        " REPLACE (trim(...) AS ...)" or "" when there is nothing to trim
+    """
+    skip = {c.lower() for c in (exclude or [])}
+    cols = [c for c in (string_columns or []) if c.lower() not in skip]
+    if not cols:
+        return ""
+    replacements = ", ".join(
+        f'trim("{c}", E\'{_TRIM_CHARS}\') AS "{c}"' for c in cols
+    )
+    return f" REPLACE ({replacements})"
+
+
 def build_read_reproject_query(source_inputs: Union[str, List[str]], source_crs: Optional[str],
                                target_crs: str, geom_col: str = "geom", layer: Optional[str] = None,
                                verbose: bool = False, geom_is_blob: bool = False,
-                               simplify_tolerance: Optional[float] = None) -> str:
+                               simplify_tolerance: Optional[float] = None,
+                               trim_columns: Optional[List[str]] = None) -> str:
     """
     Build DuckDB query to read and reproject data. Can handle multiple input files.
 
@@ -599,6 +689,9 @@ def build_read_reproject_query(source_inputs: Union[str, List[str]], source_crs:
         simplify_tolerance: When set, simplify each geometry to this tolerance (in
             target-CRS units) via ST_SimplifyPreserveTopology, applied AFTER
             reprojection so the tolerance is in the output CRS (issue #132).
+        trim_columns: String columns to strip leading/trailing whitespace from
+            (--trim-strings, issue #180). Applied via star-REPLACE so every other
+            column, and the column order, is untouched.
 
     Returns:
         DuckDB SQL query string
@@ -636,11 +729,15 @@ def build_read_reproject_query(source_inputs: Union[str, List[str]], source_crs:
 
     layer_param = f", layer='{layer}'" if layer else ""
 
+    # Trim string attributes in place (issue #180). REPLACE cannot name the
+    # geometry column, which the star already excludes, so it is filtered out.
+    replace_clause = trim_replace_clause(trim_columns, exclude=[geom_col])
+
     # helper to format a single SELECT
     def make_select(src):
         return f"""
         SELECT
-            * EXCLUDE ({geom_col}),
+            * EXCLUDE ({geom_col}){replace_clause},
             {geom_expr}
         FROM ST_Read('{src}'{layer_param})
         """
@@ -688,7 +785,8 @@ def process_parquet_input(
     progress: bool = True,
     target_crs: str = "EPSG:4326",
     verbose: bool = False,
-    simplify_tolerance: Optional[float] = None
+    simplify_tolerance: Optional[float] = None,
+    trim_strings: bool = False
 ):
     """
     Process a parquet input file to ensure it has global ID and cloud optimization.
@@ -710,6 +808,10 @@ def process_parquet_input(
         progress: Show progress during conversion
         target_crs: Target CRS for output (default: EPSG:4326)
         verbose: Print detailed debug information
+        simplify_tolerance: Optional geometry simplification tolerance in the
+            parquet's own CRS units (issue #132)
+        trim_strings: Strip leading/trailing whitespace from every VARCHAR column
+            (issue #180)
     """
     print(f"Processing parquet file: {source_url}")
     print(f"               Output to: {destination}")
@@ -812,6 +914,18 @@ def process_parquet_input(
                 f".to_parquet('fixed.parquet', geometry_encoding='WKB')"
             )
 
+        # Trim string attributes in place when asked (issue #180). Computed from
+        # the same DESCRIBE used above; the geometry column can never be VARCHAR
+        # here (it is GEOMETRY or BLOB), but exclude it anyway for safety since
+        # REPLACE cannot name a column the star excludes.
+        trim_clause = ""
+        if trim_strings:
+            string_cols = string_columns_from_describe(columns)
+            trim_clause = trim_replace_clause(
+                string_cols, exclude=[c for c in (geom_blob_col, geom_native_col) if c]
+            )
+            print(f"  Trimming whitespace from {len(string_cols)} string column(s)")
+
         # Build the geometry projection: cast a BLOB WKB column to GEOMETRY, and/or
         # apply simplification (issue #132). Tolerance is in the parquet's own CRS
         # units (assumed target_crs — this path does not reproject).
@@ -823,9 +937,9 @@ def process_parquet_input(
             if simplify_tolerance is not None:
                 print(f"  Simplifying geometry with tolerance {simplify_tolerance} (target-CRS units)")
                 base_geom = f'ST_SimplifyPreserveTopology({base_geom}, {simplify_tolerance})'
-            cols_expr = f'* EXCLUDE ("{geom_name}"), {base_geom} AS "{geom_name}"'
+            cols_expr = f'* EXCLUDE ("{geom_name}"){trim_clause}, {base_geom} AS "{geom_name}"'
         else:
-            cols_expr = "*"
+            cols_expr = f"*{trim_clause}"
 
         # Build query to read, cast geometry, and optionally add ID
         if needs_id:
@@ -892,6 +1006,7 @@ def process_csv_input(
     target_crs: str = "EPSG:4326",
     verbose: bool = False,
     simplify_tolerance: Optional[float] = None,
+    trim_strings: bool = False,
 ):
     """
     Convert a CSV with latitude/longitude columns into point GeoParquet (issue #78).
@@ -914,6 +1029,8 @@ def process_csv_input(
             this differs.
         verbose: Print detailed debug information
         simplify_tolerance: Unused for points (kept for a uniform call signature)
+        trim_strings: Strip leading/trailing whitespace from every VARCHAR column
+            (issue #180)
     """
     print(f"Processing CSV point file: {source_url}")
     print(f"                Output to: {destination}")
@@ -978,9 +1095,18 @@ def process_csv_input(
             point_expr = f"ST_Transform({point_expr}, 'EPSG:4326', '{target_crs}', always_xy := true)"
         geom_expr = f"ST_MakeValid({point_expr}) AS geom"
 
+        # Trim string attributes in place when asked (issue #180). The lat/lon
+        # columns are numeric after read_csv_auto's type inference, so they are
+        # untouched even when they are carried through as attributes.
+        trim_clause = ""
+        if trim_strings:
+            string_cols = string_columns_from_describe(columns)
+            trim_clause = trim_replace_clause(string_cols)
+            print(f"  Trimming whitespace from {len(string_cols)} string column(s)")
+
         id_prefix = f"ROW_NUMBER() OVER () AS {id_col_name}, " if needs_id else ""
         query = f"""
-            SELECT {id_prefix}*, {geom_expr}
+            SELECT {id_prefix}*{trim_clause}, {geom_expr}
             FROM read_csv_auto('{read_url}')
         """
 
@@ -1119,7 +1245,8 @@ def convert_to_parquet(
     verbose: bool = False,
     simplify_tolerance: Optional[float] = None,
     lat_column: Optional[str] = None,
-    lon_column: Optional[str] = None
+    lon_column: Optional[str] = None,
+    trim_strings: bool = False
 ):
     """
     Convert a vector dataset to optimized GeoParquet.
@@ -1151,6 +1278,10 @@ def convert_to_parquet(
             not given, issue #78)
         lon_column: Longitude column name for CSV point input (auto-detected if
             not given, issue #78)
+        trim_strings: Strip leading/trailing whitespace from every string
+            (VARCHAR) attribute column. Off by default so outputs stay faithful
+            to the source; opt in for sources whose categorical fields carry
+            stray whitespace (e.g. WDPA NO_TAKE = 'All ', issue #180).
     """
     # CSV with lat/lon columns -> point geometry (issue #78). Handled before the
     # ST_Read path since CSV is not a spatial format GDAL/ST_Read opens directly.
@@ -1168,6 +1299,7 @@ def convert_to_parquet(
             progress=progress,
             target_crs=target_crs,
             verbose=verbose,
+            trim_strings=trim_strings,
         )
 
     # Check if input is already parquet
@@ -1200,7 +1332,8 @@ def convert_to_parquet(
             progress=progress,
             target_crs=target_crs,
             verbose=verbose,
-            simplify_tolerance=simplify_tolerance
+            simplify_tolerance=simplify_tolerance,
+            trim_strings=trim_strings
         )
 
     # Original processing for non-parquet inputs
@@ -1333,6 +1466,14 @@ def convert_to_parquet(
                 geom_col, geom_is_blob = get_geometry_column(flattened_source, layer=flat_layer, verbose=verbose)
                 print(f"  Geometry column (flattened): {geom_col}")
 
+        # Step 1d: List string columns to trim (issue #180). Detected on the
+        # representative source; a UNION ALL of multiple sources is positional
+        # and already requires matching schemas, so one probe covers them all.
+        trim_columns = None
+        if trim_strings:
+            trim_columns = get_string_columns(representative_source, layer=layer, verbose=verbose)
+            print(f"  Trimming whitespace from {len(trim_columns)} string column(s)")
+
         # Step 2: Build read/reproject query
         print("  Building read/reproject query...")
         query = build_read_reproject_query(
@@ -1344,6 +1485,7 @@ def convert_to_parquet(
             verbose=verbose,
             geom_is_blob=geom_is_blob,
             simplify_tolerance=simplify_tolerance,
+            trim_columns=trim_columns,
         )
 
         # Step 3: Check ID column and wrap query if needed
@@ -1429,6 +1571,9 @@ Examples:
 
   # Convert and specify ID column
   cng-convert-to-parquet input.shp output.parquet --id-column objectid
+
+  # Convert a GDB layer, trimming whitespace from string attributes
+  cng-convert-to-parquet WDPA.gdb wdpa.parquet --layer WDPA_poly --trim-strings
         """
     )
 
@@ -1456,6 +1601,12 @@ Examples:
                             "(degrees for EPSG:4326; e.g. 0.0001 ~ 10 m at the equator) "
                             "via ST_SimplifyPreserveTopology, applied after reprojection. "
                             "Right-sizes high-vertex sources for tiling/hex.")
+    parser.add_argument("--trim-strings", action="store_true",
+                       help="Strip leading/trailing whitespace (spaces, tabs, newlines) "
+                            "from every string column. Off by default: conversion stays "
+                            "faithful to the source. Opt in for sources whose categorical "
+                            "fields carry stray whitespace, which silently breaks equality "
+                            "filters (e.g. WDPA NO_TAKE = 'All ' vs 'All').")
     parser.add_argument("--layer", help="Layer name for multi-layer datasets (e.g., GDB files)")
     parser.add_argument("--lat-column", default=None,
                        help="Latitude column for CSV point input (auto-detected from "
@@ -1490,7 +1641,8 @@ Examples:
             verbose=args.verbose,
             simplify_tolerance=args.simplify_tolerance,
             lat_column=args.lat_column,
-            lon_column=args.lon_column
+            lon_column=args.lon_column,
+            trim_strings=args.trim_strings
         )
         sys.exit(0)
     except Exception as e:

--- a/tests/test_convert_to_parquet.py
+++ b/tests/test_convert_to_parquet.py
@@ -18,6 +18,9 @@ from cng_datasets.vector.convert_to_parquet import (
     _localize_gdb,
     is_csv_file,
     _resolve_latlon_columns,
+    string_columns_from_describe,
+    trim_replace_clause,
+    get_string_columns,
 )
 
 
@@ -253,6 +256,157 @@ class TestSimplifyTolerance:
             n_out = con.execute(f"SELECT ST_NPoints(geom) FROM read_parquet('{out}')").fetchone()[0]
             con.close()
             assert n_out == n_in
+
+
+class TestTrimStrings:
+    """Issue #180: opt-in --trim-strings strips leading/trailing whitespace from
+    string attributes, so equality filters like NO_TAKE = 'All' stop silently
+    returning zero rows on sources that store 'All ' (WDPA)."""
+
+    def test_string_columns_from_describe_picks_varchar_only(self):
+        described = [
+            ("NO_TAKE", "VARCHAR"), ("WDPAID", "BIGINT"), ("tags", "VARCHAR[]"),
+            ("meta", 'STRUCT("a" VARCHAR)'), ("geom", "GEOMETRY"),
+        ]
+        assert string_columns_from_describe(described) == ["NO_TAKE"]
+
+    def test_trim_replace_clause_quotes_and_excludes(self):
+        clause = trim_replace_clause(["NO_TAKE", "Odd Name"], exclude=["geom"])
+        assert clause.startswith(" REPLACE (")
+        assert 'trim("NO_TAKE"' in clause and 'AS "NO_TAKE"' in clause
+        assert 'trim("Odd Name"' in clause
+        # A geometry column named in the star's EXCLUDE cannot be REPLACEd
+        assert trim_replace_clause(["geom"], exclude=["GEOM"]) == ""
+
+    def test_trim_replace_clause_empty_without_columns(self):
+        assert trim_replace_clause(None) == ""
+        assert trim_replace_clause([]) == ""
+
+    def test_trim_clause_strips_space_tab_newline(self):
+        """The emitted SQL trims tabs and newlines too, not just spaces (DuckDB's
+        one-argument trim() only removes spaces)."""
+        con = duckdb.connect()
+        try:
+            clause = trim_replace_clause(["a", "b"])
+            row = con.execute(
+                f"SELECT *{clause} FROM (SELECT 'All ' AS a, e'\t x \n' AS b)"
+            ).fetchone()
+        finally:
+            con.close()
+        assert row == ("All", "x")
+
+    def test_query_builder_trims_only_requested_columns(self):
+        sql = build_read_reproject_query(
+            "dummy.gpkg", source_crs=None, target_crs="EPSG:4326", geom_col="geom",
+            trim_columns=["NO_TAKE"],
+        )
+        assert 'trim("NO_TAKE"' in sql
+        assert "* EXCLUDE (geom) REPLACE (" in sql
+
+    def test_query_builder_no_trim_by_default(self):
+        sql = build_read_reproject_query(
+            "dummy.gpkg", source_crs=None, target_crs="EPSG:4326", geom_col="geom"
+        )
+        assert "REPLACE" not in sql and "trim(" not in sql
+
+    def _write_geojson(self, path, value):
+        feature = {
+            "type": "FeatureCollection",
+            "crs": {"type": "name", "properties": {"name": "urn:ogc:def:crs:OGC:1.3:CRS84"}},
+            "features": [{
+                "type": "Feature",
+                "properties": {"NO_TAKE": value, "WDPAID": 1},
+                "geometry": {"type": "Point", "coordinates": [-122.3, 37.9]},
+            }],
+        }
+        Path(path).write_text(json.dumps(feature))
+
+    def test_st_read_path_trims_end_to_end(self):
+        """A GDB/GeoJSON-style source whose category carries a trailing space
+        becomes filterable by the clean value, with other columns intact."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            src, out = f"{tmpdir}/src.geojson", f"{tmpdir}/out.parquet"
+            self._write_geojson(src, "All ")
+
+            convert_to_parquet(source_url=src, destination=out, trim_strings=True, progress=False)
+
+            con = duckdb.connect()
+            try:
+                value, wdpaid = con.execute(
+                    f"SELECT NO_TAKE, WDPAID FROM read_parquet('{out}')"
+                ).fetchone()
+                n_match = con.execute(
+                    f"SELECT COUNT(*) FROM read_parquet('{out}') WHERE NO_TAKE = 'All'"
+                ).fetchone()[0]
+                cols = [r[0] for r in con.execute(f"DESCRIBE SELECT * FROM read_parquet('{out}')").fetchall()]
+            finally:
+                con.close()
+            assert value == "All"
+            assert n_match == 1
+            assert wdpaid == 1
+            assert "_cng_fid" in cols and "geom" in cols
+
+    def test_st_read_path_faithful_by_default(self):
+        """Off by default: the source's trailing space is preserved."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            src, out = f"{tmpdir}/src.geojson", f"{tmpdir}/out.parquet"
+            self._write_geojson(src, "All ")
+
+            convert_to_parquet(source_url=src, destination=out, progress=False)
+
+            con = duckdb.connect()
+            try:
+                value = con.execute(f"SELECT NO_TAKE FROM read_parquet('{out}')").fetchone()[0]
+            finally:
+                con.close()
+            assert value == "All "
+
+    def test_parquet_path_trims_end_to_end(self):
+        """The already-parquet path trims too, keeping the geometry column."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            src, out = f"{tmpdir}/src.parquet", f"{tmpdir}/out.parquet"
+            con = duckdb.connect(); con.install_extension("spatial"); con.load_extension("spatial")
+            con.execute(f"""
+                COPY (SELECT ' All ' AS NO_TAKE, 42 AS WDPAID,
+                             ST_Point(-122.3, 37.9) AS geom)
+                TO '{src}' (FORMAT PARQUET)
+            """)
+
+            convert_to_parquet(source_url=src, destination=out, trim_strings=True, progress=False)
+
+            value, wdpaid, is_point = con.execute(f"""
+                SELECT NO_TAKE, WDPAID, ST_GeometryType(geom) = 'POINT'
+                FROM read_parquet('{out}')
+            """).fetchone()
+            untrimmed = con.execute(f"SELECT NO_TAKE FROM read_parquet('{src}')").fetchone()[0]
+            con.close()
+            assert value == "All"
+            assert untrimmed == " All "
+            assert wdpaid == 42 and is_point
+
+    def test_csv_path_trims_end_to_end(self):
+        """CSV point input trims string attributes but leaves coordinates alone."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            src, out = f"{tmpdir}/pts.csv", f"{tmpdir}/out.parquet"
+            Path(src).write_text('name,latitude,longitude\n"All ",37.9,-122.3\n')
+
+            convert_to_parquet(source_url=src, destination=out, trim_strings=True, progress=False)
+
+            con = duckdb.connect(); con.install_extension("spatial"); con.load_extension("spatial")
+            try:
+                name, lat, is_point = con.execute(f"""
+                    SELECT name, latitude, ST_GeometryType(geom) = 'POINT'
+                    FROM read_parquet('{out}')
+                """).fetchone()
+            finally:
+                con.close()
+            assert name == "All"
+            assert lat == 37.9 and is_point
+
+    def test_get_string_columns_survives_unreadable_source(self):
+        """Detection failure must not fail the conversion — trimming is opt-in
+        convenience, so an unreadable probe degrades to 'trim nothing'."""
+        assert get_string_columns("/nonexistent/nope.gpkg") == []
 
 
 class TestCsvPointInput:

--- a/tests/test_k8s_workflows.py
+++ b/tests/test_k8s_workflows.py
@@ -1380,3 +1380,38 @@ class TestProfileLoading:
 
 if __name__ == "__main__":
     pytest.main([__file__, "-v"])
+
+
+class TestTrimStringsWiring:
+    """Issue #180: --trim-strings reaches the generated convert job command."""
+
+    def test_convert_job_includes_trim_flag(self, monkeypatch):
+        import cng_datasets.k8s.workflows as wf
+        monkeypatch.setattr(wf, "_count_source_features", lambda *a, **k: 5000)
+        with tempfile.TemporaryDirectory() as tmpdir:
+            generate_dataset_workflow(
+                dataset_name="trim-ds",
+                source_url="https://example.com/wdpa.gdb",
+                bucket="test-bucket",
+                output_dir=tmpdir,
+                h3_resolution=10,           # skip network geometry detection
+                trim_strings=True,
+            )
+            convert_yaml = yaml.safe_load(open(Path(tmpdir) / "trim-ds-convert.yaml"))
+            cmd = str(convert_yaml["spec"]["template"]["spec"]["containers"][0]["command"])
+            assert "--trim-strings" in cmd
+
+    def test_convert_job_omits_flag_by_default(self, monkeypatch):
+        import cng_datasets.k8s.workflows as wf
+        monkeypatch.setattr(wf, "_count_source_features", lambda *a, **k: 5000)
+        with tempfile.TemporaryDirectory() as tmpdir:
+            generate_dataset_workflow(
+                dataset_name="notrim-ds",
+                source_url="https://example.com/wdpa.gdb",
+                bucket="test-bucket",
+                output_dir=tmpdir,
+                h3_resolution=10,
+            )
+            convert_yaml = yaml.safe_load(open(Path(tmpdir) / "notrim-ds-convert.yaml"))
+            cmd = str(convert_yaml["spec"]["template"]["spec"]["containers"][0]["command"])
+            assert "--trim-strings" not in cmd


### PR DESCRIPTION
Closes #180.

## Why

Categorical string fields in GDB/Shapefile sources sometimes carry leading/trailing whitespace upstream — WDPA stores the fully-no-take category as `'All '` in the source GDB itself. The conversion is faithful and not at fault, but every consumer's `WHERE NO_TAKE = 'All'` then returns **zero rows**, and a declared `values: ["All", ...]` mismatches the ingested `'All '`. Patching it per-recipe re-implements the same transform N times and is undone at the next ingest of a rolling collection.

## What

An opt-in flag, **default off**, so existing outputs are byte-identical and no attribute value is mutated without the operator asking:

```bash
cng-convert-to-parquet WDPA.gdb wdpa.parquet --layer WDPA_poly --trim-strings
cng-datasets workflow --dataset wdpa --source-url ... --bucket ... --trim-strings
```

- `trim_replace_clause()` emits a DuckDB star-`REPLACE` (`trim(col, ...) AS col`) for **VARCHAR columns only**, so column order, non-string columns, geometry handling and the synthetic `_cng_fid` wrapper are all untouched — one line per string column, as the issue proposed.
- Trims spaces, tabs, CRs and LFs. DuckDB's one-argument `trim()` strips ASCII spaces only, so the character set is passed explicitly; interior whitespace is deliberately left alone (per the issue's open question — leading/trailing is the empirically damaging case).
- Wired into all three convert paths: `ST_Read` (string columns probed on the representative source), already-parquet, and CSV lat/lon points — each reusing its existing `DESCRIBE`, and the CSV path leaving the numeric lat/lon columns alone.
- `cng-datasets workflow --trim-strings` is threaded into the generated convert job command.

On the permanence question: implemented as a permanent opt-in, matching the issue's lean. Nothing here assumes a future default-on.

## Tests

13 new tests: clause construction/quoting/exclusions, tab+newline stripping, end-to-end trim **and** faithful-by-default on the ST_Read, parquet and CSV paths, and the k8s convert-job flag wiring (present when asked, absent by default).

`pytest tests/ --ignore=tests/test_cli.py --ignore=tests/test_raster.py` goes 221 → 234 passing with an identical failure set to clean `main` (the remaining failures/errors are the pre-existing network- and GDAL-python-dependent ones in this sandbox).