### PR TITLE
Warn on non-joinable H3 builds; safe Armada priority defaults (#182, #183)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- `--armada-priority-class` on `workflow` and `raster-workflow`: the Armada priority class was previously unreachable from the CLI, since `convert_workflow_to_armada` neither accepted nor forwarded one. Accepts a shorthand (`default`, `preemptible`, `high`) or a literal class name, and the generated-workflow summary now reports the class in effect (#183)
+
+### Changed
+- **Breaking (Armada backend):** converted jobs now default to the non-preemptible `armada-default` instead of `armada-preemptible`, and a k8s `opportunistic` priority class no longer maps onto `armada-preemptible`. An opportunistic k8s pod is preempted but recreated by its Job controller; a preempted Armada job is not rescheduled at all, and the Job-level retry settings do not survive conversion — so the old default turned multi-hour work into preemptible work with no retry and no rescheduling. Pass `--armada-priority-class preemptible` to opt back in, which is the right default once units are small enough that losing one is cheap (#183)
+
+### Fixed
+- Converting a k8s Job to Armada now warns when Job-level retry settings (`backoffLimit`, `backoffLimitPerIndex`, `maxFailedIndexes`) are dropped, naming what is lost; conversion reads `spec.template.spec`, so these were silently discarded. Settings that grant no retries (a `0` value) are not reported, and the warning additionally flags the preemptible case, where a preemption loses the whole unit (#183)
+- `raster` now warns when a build has no path to `h8`, the catalog's universal join key, naming the consequence: the output cannot be joined against the rest of the catalog. Two cases, both previously silent — the target resolution is coarser than h8 (`detect_optimal_h3_resolution` targets ~3x the source pixel edge, which agrees with the catalog at fine pixels but lands on h6 for a ~1 km global raster, so a caller who omitted `--h3-resolution` got a non-joinable dataset with only an informational log line), or the target is finer than h8 and h8 is not among `--parent-resolutions`, whose raster default is `0` alone. Resolution detection itself is unchanged (#182)
+- Stale default Armada queue in `convert_workflow_to_armada` (`biodiversity` → `geo-workflows`); the workflow generators pass the namespace explicitly, so this affects direct API callers (#183)
+
 ## [0.3.1] - 2026-07-21
 
 ### Fixed

--- a/cng_datasets/cli.py
+++ b/cng_datasets/cli.py
@@ -129,6 +129,7 @@ def main():
     workflow_parser.add_argument("--repartition-storage", type=str, default="50Gi", help="Ephemeral storage request/limit for repartition job pod (default: 50Gi)")
     workflow_parser.add_argument("--repartition-memory", type=str, default="32Gi", help="Memory request/limit for repartition job pod (default: 32Gi)")
     workflow_parser.add_argument("--backend", choices=["k8s", "armada"], default="k8s", help="Job backend: 'k8s' for standard Kubernetes Jobs (default), 'armada' for Armada queue submission")
+    workflow_parser.add_argument("--armada-priority-class", default=None, metavar="CLASS", help="Armada priority class when --backend armada: a shorthand ('default', 'preemptible', 'high') or a literal class name. Default is non-preemptible 'armada-default' — preempted Armada jobs are not rescheduled and k8s Job-level retry settings do not survive conversion")
     # Cluster/storage configuration flags
     workflow_parser.add_argument("--profile", default=None, metavar="NAME_OR_PATH", help="Cluster profile name (e.g. 'nrp') or path to a YAML profile file. Explicit flags below override profile values.")
     workflow_parser.add_argument("--s3-endpoint", default=None, metavar="HOST", help="Internal S3 endpoint for jobs (default from profile, or rook-ceph-rgw-nautiluss3.rook)")
@@ -171,6 +172,7 @@ def main():
     raster_workflow_parser.add_argument("--band", type=int, help="Extract single band from multi-band sources, 1-indexed (multi-tile only)")
     raster_workflow_parser.add_argument("--output-cog-name", help="S3 key for intermediate COG (default: {dataset}-cog.tif)")
     raster_workflow_parser.add_argument("--backend", choices=["k8s", "armada"], default="k8s", help="Job backend: 'k8s' for standard Kubernetes Jobs (default), 'armada' for Armada queue submission")
+    raster_workflow_parser.add_argument("--armada-priority-class", default=None, metavar="CLASS", help="Armada priority class when --backend armada: a shorthand ('default', 'preemptible', 'high') or a literal class name. Default is non-preemptible 'armada-default' — preempted Armada jobs are not rescheduled and k8s Job-level retry settings do not survive conversion")
     # Cluster/storage configuration flags
     raster_workflow_parser.add_argument("--profile", default=None, metavar="NAME_OR_PATH", help="Cluster profile name (e.g. 'nrp') or path to a YAML profile file. Explicit flags below override profile values.")
     raster_workflow_parser.add_argument("--s3-endpoint", default=None, metavar="HOST", help="Internal S3 endpoint for jobs (default from profile, or rook-ceph-rgw-nautiluss3.rook)")
@@ -388,6 +390,7 @@ def _dispatch(args):
             simplify_tolerance=args.simplify_tolerance,
             trim_strings=args.trim_strings,
             backend=args.backend,
+            armada_priority_class=args.armada_priority_class,
             hex_storage=args.hex_storage,
             repartition_storage=args.repartition_storage,
             repartition_memory=args.repartition_memory,
@@ -430,6 +433,7 @@ def _dispatch(args):
             band=getattr(args, 'band', None),
             output_cog_name=getattr(args, 'output_cog_name', None),
             backend=args.backend,
+            armada_priority_class=args.armada_priority_class,
             profile=args.profile,
             s3_endpoint=args.s3_endpoint,
             s3_public_endpoint=args.s3_public_endpoint,

--- a/cng_datasets/k8s/armada.py
+++ b/cng_datasets/k8s/armada.py
@@ -13,17 +13,92 @@ from typing import Dict, Any, List, Optional
 from pathlib import Path
 
 
-# Armada priority classes available on NRP
+# Armada priority classes available on NRP, keyed by the shorthand accepted
+# by --armada-priority-class
 ARMADA_PRIORITY_CLASSES = {
     "default": "armada-default",        # non-preemptible, priority 100
     "preemptible": "armada-preemptible", # preemptible, priority 50
     "high": "armada-high-priority",      # non-preemptible, priority 1000
 }
 
-# Map from k8s priority classes to Armada equivalents
-K8S_TO_ARMADA_PRIORITY = {
-    "opportunistic": "armada-preemptible",
-}
+# Non-preemptible. The converter reproduces the *shape* of the k8s job it reads
+# — currently one Armada job per completion, same cpu/memory/runtime — so the
+# units it emits are long-running. A preempted Armada job is not rescheduled
+# (nrp.ai/documentation/userdocs/running/scheduling/) and the Job-level retry
+# settings do not survive conversion, so preemptible is the wrong default until
+# units are small enough that losing one is cheap (issue #183).
+DEFAULT_ARMADA_PRIORITY_CLASS = "armada-default"
+
+# Map from k8s priority classes to Armada equivalents.
+#
+# "opportunistic" is deliberately absent. It is preemptible on the k8s side, but
+# an opportunistic pod is preempted and then *recreated by its Job controller*,
+# whereas a preempted Armada job simply stops. Mapping it onto
+# "armada-preemptible" preserves the preemption and drops the recovery, which is
+# how a converted long job ends up with neither retries nor rescheduling. The
+# closest behavioural equivalent — work that eventually finishes — is the
+# non-preemptible default; pass priority_class explicitly to override (#183).
+K8S_TO_ARMADA_PRIORITY: Dict[str, str] = {}
+
+# Job-level retry settings that live outside the podSpec and so cannot survive
+# conversion: Armada exposes no per-job equivalent (retries are a server-side
+# setting), so these are dropped rather than remapped (issue #183).
+K8S_JOB_LEVEL_RETRY_FIELDS = (
+    "backoffLimit",
+    "backoffLimitPerIndex",
+    "maxFailedIndexes",
+)
+
+
+def resolve_armada_priority_class(value: Optional[str]) -> Optional[str]:
+    """
+    Resolve a user-supplied priority class to a literal Armada class name.
+
+    Accepts the shorthands in ARMADA_PRIORITY_CLASSES ("default",
+    "preemptible", "high") and passes any other non-empty string through
+    unchanged, so cluster-specific classes stay usable.
+    """
+    if value is None or value == "":
+        return None
+    return ARMADA_PRIORITY_CLASSES.get(value, value)
+
+
+def _warn_dropped_retry_settings(job_spec: Dict[str, Any], priority_class: str):
+    """
+    Warn about k8s Job-level retry settings that conversion discards.
+
+    `_extract_pod_spec` takes `spec.template.spec`, so everything set at Job
+    level is left behind. Silently dropping the retry budget is worst when the
+    converted job also lands at preemptible priority: multi-hour work, no
+    retries, no rescheduling (issue #183).
+    """
+    spec = job_spec.get("spec", {})
+    # A field set to 0 grants no retries, so dropping it loses nothing — only
+    # warn when a real retry budget disappears.
+    dropped = {
+        field: spec[field]
+        for field in K8S_JOB_LEVEL_RETRY_FIELDS
+        if spec.get(field)
+    }
+    if not dropped:
+        return
+
+    settings = ", ".join(f"{k}={v}" for k, v in dropped.items())
+    name = job_spec.get("metadata", {}).get("name", "job")
+    message = (
+        f"⚠ Dropping k8s Job-level retry settings when converting {name} to "
+        f"Armada: {settings}.\n"
+        f"  Armada has no per-job equivalent (retries are a server-side "
+        f"setting), so a failed job stays failed."
+    )
+    if priority_class == ARMADA_PRIORITY_CLASSES["preemptible"]:
+        message += (
+            f"\n  This job is also preemptible, and preempted Armada jobs are "
+            f"not rescheduled — a preemption\n"
+            f"  loses the whole unit. Consider "
+            f"--armada-priority-class default for long-running units."
+        )
+    print(message)
 
 
 def _extract_pod_spec(job_spec: Dict[str, Any]) -> Dict[str, Any]:
@@ -41,7 +116,7 @@ def _extract_pod_spec(job_spec: Dict[str, Any]) -> Dict[str, Any]:
     return pod_spec
 
 
-def _map_priority_class(job_spec: Dict[str, Any], default: str = "armada-preemptible") -> str:
+def _map_priority_class(job_spec: Dict[str, Any], default: str = DEFAULT_ARMADA_PRIORITY_CLASS) -> str:
     """Map a k8s Job's priorityClassName to the Armada equivalent."""
     k8s_priority = job_spec.get("spec", {}).get("template", {}).get(
         "spec", {}
@@ -62,13 +137,17 @@ def k8s_job_to_armada(
         job_spec: Standard k8s batch/v1 Job spec dict
         queue: Armada queue (typically matches k8s namespace)
         job_set_id: Unique identifier for this job set
-        priority_class: Armada priority class (auto-mapped from k8s if None)
+        priority_class: Armada priority class, either a literal name
+            ("armada-default") or a shorthand ("default", "preemptible",
+            "high"). Defaults to DEFAULT_ARMADA_PRIORITY_CLASS when None.
 
     Returns:
         Armada submission dict ready for YAML serialization
     """
+    priority_class = resolve_armada_priority_class(priority_class)
     if priority_class is None:
         priority_class = _map_priority_class(job_spec)
+    _warn_dropped_retry_settings(job_spec, priority_class)
 
     namespace = job_spec["metadata"].get("namespace", queue)
     pod_spec = _extract_pod_spec(job_spec)
@@ -101,13 +180,17 @@ def k8s_indexed_job_to_armada(
         job_spec: k8s Job spec with completionMode: Indexed
         queue: Armada queue
         job_set_id: Unique identifier for this job set
-        priority_class: Armada priority class (auto-mapped from k8s if None)
+        priority_class: Armada priority class, either a literal name
+            ("armada-default") or a shorthand ("default", "preemptible",
+            "high"). Defaults to DEFAULT_ARMADA_PRIORITY_CLASS when None.
 
     Returns:
         Armada submission dict with N jobs (one per completion index)
     """
+    priority_class = resolve_armada_priority_class(priority_class)
     if priority_class is None:
         priority_class = _map_priority_class(job_spec)
+    _warn_dropped_retry_settings(job_spec, priority_class)
 
     completions = job_spec["spec"]["completions"]
     namespace = job_spec["metadata"].get("namespace", queue)
@@ -166,8 +249,9 @@ def save_armada_yaml(armada_spec: Dict[str, Any], output_path: str):
 def convert_workflow_to_armada(
     k8s_yaml_dir: str,
     dataset_name: str,
-    queue: str = "biodiversity",
+    queue: str = "geo-workflows",
     output_dir: Optional[str] = None,
+    priority_class: Optional[str] = None,
 ) -> List[str]:
     """
     Convert a directory of k8s Job YAMLs to Armada submission YAMLs.
@@ -178,8 +262,13 @@ def convert_workflow_to_armada(
     Args:
         k8s_yaml_dir: Directory containing k8s Job YAML files
         dataset_name: Dataset name (used for job set IDs)
-        queue: Armada queue name
+        queue: Armada queue name. On NRP, queues map one-to-one onto cluster
+            namespaces, so callers normally pass the workflow's namespace.
         output_dir: Output directory (defaults to k8s_yaml_dir)
+        priority_class: Armada priority class applied to every converted job,
+            as a literal name or a shorthand ("default", "preemptible",
+            "high"). Defaults to DEFAULT_ARMADA_PRIORITY_CLASS when None
+            (issue #183).
 
     Returns:
         List of generated Armada YAML file paths
@@ -212,11 +301,17 @@ def convert_workflow_to_armada(
 
         if is_indexed:
             armada_spec = k8s_indexed_job_to_armada(
-                job_spec, queue=queue, job_set_id=job_set_id
+                job_spec,
+                queue=queue,
+                job_set_id=job_set_id,
+                priority_class=priority_class,
             )
         else:
             armada_spec = k8s_job_to_armada(
-                job_spec, queue=queue, job_set_id=job_set_id
+                job_spec,
+                queue=queue,
+                job_set_id=job_set_id,
+                priority_class=priority_class,
             )
 
         out_file = out_path / f"armada-{yaml_file.name}"

--- a/cng_datasets/k8s/armada.py
+++ b/cng_datasets/k8s/armada.py
@@ -93,10 +93,10 @@ def _warn_dropped_retry_settings(job_spec: Dict[str, Any], priority_class: str):
     )
     if priority_class == ARMADA_PRIORITY_CLASSES["preemptible"]:
         message += (
-            f"\n  This job is also preemptible, and preempted Armada jobs are "
-            f"not rescheduled — a preemption\n"
-            f"  loses the whole unit. Consider "
-            f"--armada-priority-class default for long-running units."
+            "\n  This job is also preemptible, and preempted Armada jobs are "
+            "not rescheduled — a preemption\n"
+            "  loses the whole unit. Consider "
+            "--armada-priority-class default for long-running units."
         )
     print(message)
 

--- a/cng_datasets/k8s/workflows.py
+++ b/cng_datasets/k8s/workflows.py
@@ -13,7 +13,11 @@ import re
 import shlex
 import yaml
 from .jobs import K8sJobManager
-from .armada import convert_workflow_to_armada
+from .armada import (
+    convert_workflow_to_armada,
+    resolve_armada_priority_class,
+    DEFAULT_ARMADA_PRIORITY_CLASS,
+)
 
 # Keys that ClusterConfig accepts (used for profile validation)
 _CONFIG_KEYS = {
@@ -488,6 +492,7 @@ def generate_dataset_workflow(
     trim_strings: bool = False,
     pmtiles_max_zoom: Optional[int] = None,
     backend: str = "k8s",
+    armada_priority_class: Optional[str] = None,
     hex_storage: str = "10Gi",
     repartition_storage: str = "50Gi",
     repartition_memory: str = "32Gi",
@@ -529,6 +534,12 @@ def generate_dataset_workflow(
         hex_memory: Memory request/limit for hex job pods (default: "8Gi")
         max_parallelism: Maximum parallelism for hex jobs (default: 50)
         max_completions: Maximum job completions - increase to reduce chunk size (default: 200)
+        armada_priority_class: Armada priority class for the `armada` backend —
+            a literal name ("armada-default") or a shorthand ("default",
+            "preemptible", "high"). Defaults to non-preemptible, since a
+            preempted Armada job is not rescheduled and the k8s Job-level retry
+            settings do not survive conversion (issue #183). Ignored when
+            backend is "k8s".
         intermediate_chunk_size: Number of rows to process in pass 2 (unnesting arrays) - reduce if hitting OOM (default: 10)
         source_url: (Deprecated) Use source_urls instead. Kept for backwards compatibility.
     """
@@ -649,8 +660,15 @@ def generate_dataset_workflow(
             k8s_yaml_dir=str(output_path),
             dataset_name=k8s_name,
             queue=namespace,
+            priority_class=armada_priority_class,
+        )
+        effective_priority = (
+            resolve_armada_priority_class(armada_priority_class)
+            or DEFAULT_ARMADA_PRIORITY_CLASS
         )
         print(f"\n✓ Generated Armada workflow for {dataset_name}")
+        print(f"  Armada priority class: {effective_priority} "
+              f"(override with --armada-priority-class)")
         print(f"\nArmada files created in {output_dir}:")
         for f in armada_files:
             print(f"  - {Path(f).name}")
@@ -710,6 +728,7 @@ def generate_raster_workflow(
     band: Optional[int] = None,
     output_cog_name: Optional[str] = None,
     backend: str = "k8s",
+    armada_priority_class: Optional[str] = None,
     # Cluster/storage configuration — all default to None so explicit values
     # can be distinguished from "not set" when merging with a profile.
     profile: Optional[str] = None,
@@ -763,6 +782,10 @@ def generate_raster_workflow(
         target_resolution: Output pixel size in degrees for mosaic step
         band: Extract single band from multi-band sources (1-indexed) for mosaic step
         output_cog_name: S3 key for intermediate COG (default: "{k8s_name}-cog.tif")
+        armada_priority_class: Armada priority class for the `armada` backend —
+            a literal name ("armada-default") or a shorthand ("default",
+            "preemptible", "high"). Defaults to non-preemptible (issue #183).
+            Ignored when backend is "k8s".
         source_url: Deprecated alias for source_urls (single URL).
     """
     # backwards compat
@@ -863,8 +886,15 @@ def generate_raster_workflow(
             k8s_yaml_dir=str(output_path),
             dataset_name=k8s_name,
             queue=namespace,
+            priority_class=armada_priority_class,
+        )
+        effective_priority = (
+            resolve_armada_priority_class(armada_priority_class)
+            or DEFAULT_ARMADA_PRIORITY_CLASS
         )
         print(f"\n✓ Generated Armada raster workflow for {dataset_name}")
+        print(f"  Armada priority class: {effective_priority} "
+              f"(override with --armada-priority-class)")
         print(f"\nArmada files created in {output_dir}:")
         for f in armada_files:
             print(f"  - {Path(f).name}")

--- a/cng_datasets/raster/__init__.py
+++ b/cng_datasets/raster/__init__.py
@@ -1,5 +1,5 @@
 """Raster data processing utilities."""
 
-from .cog import create_cog, create_mosaic_cog, RasterProcessor, detect_optimal_h3_resolution, detect_nodata_value, is_cog
+from .cog import create_cog, create_mosaic_cog, RasterProcessor, detect_optimal_h3_resolution, detect_nodata_value, is_cog, h3_resolution_join_warning, CATALOG_JOIN_RESOLUTION
 
-__all__ = ["create_cog", "create_mosaic_cog", "RasterProcessor", "detect_optimal_h3_resolution", "detect_nodata_value", "is_cog"]
+__all__ = ["create_cog", "create_mosaic_cog", "RasterProcessor", "detect_optimal_h3_resolution", "detect_nodata_value", "is_cog", "h3_resolution_join_warning", "CATALOG_JOIN_RESOLUTION"]

--- a/cng_datasets/raster/cog.py
+++ b/cng_datasets/raster/cog.py
@@ -666,6 +666,91 @@ def detect_optimal_h3_resolution(raster_path: str, verbose: bool = True) -> int:
     return best_res
 
 
+# The catalog's universal join key. A dataset whose finest H3 resolution is
+# coarser than this carries no h8 column at all, so it cannot be joined against
+# the rest of the catalog on h8 (issue #182).
+CATALOG_JOIN_RESOLUTION = 8
+
+
+def h3_resolution_join_warning(
+    resolution: int,
+    user_specified: bool,
+    parent_resolutions: Optional[List[int]] = None,
+) -> Optional[str]:
+    """
+    Build the warning text when a build carries no path to the h8 join key.
+
+    Two ways to lose it, both silent today (issue #182):
+
+    * **Target too coarse.** `detect_optimal_h3_resolution` targets ~3x the
+      source pixel edge, which agrees with the catalog convention at fine pixels
+      and diverges as pixels coarsen — a ~1 km global raster auto-detects h6,
+      two levels below h8. Detection is only a suggestion, so a caller who omits
+      ``--h3-resolution`` gets a non-joinable dataset with no error, only an
+      informational log line.
+    * **h8 not among the parents.** A finer target only carries h8 if h8 is a
+      requested parent resolution, and the default is ``--parent-resolutions 0``
+      — so an h10 build emits h10 and h0 and nothing to join on.
+
+    Args:
+        resolution: The H3 resolution the build will actually use
+        user_specified: Whether the caller passed the resolution explicitly
+        parent_resolutions: Parent resolutions the build will emit. None skips
+            the parent check, for callers that do not know them yet.
+
+    Returns:
+        Warning text, or None when the build can join on h8
+    """
+    if resolution == CATALOG_JOIN_RESOLUTION:
+        return None
+
+    if resolution > CATALOG_JOIN_RESOLUTION:
+        if parent_resolutions is None:
+            return None
+        if CATALOG_JOIN_RESOLUTION in parent_resolutions:
+            return None
+        emitted = ", ".join(
+            f"h{r}" for r in [resolution] + sorted(parent_resolutions, reverse=True)
+        )
+        return (
+            f"⚠ This build emits {emitted} — no "
+            f"h{CATALOG_JOIN_RESOLUTION} column.\n"
+            f"  h{CATALOG_JOIN_RESOLUTION} is the catalog's universal join key, "
+            f"so the output cannot be joined against the\n"
+            f"  rest of the catalog. Add {CATALOG_JOIN_RESOLUTION} to "
+            f"--parent-resolutions to emit it."
+        )
+
+    consequence = (
+        f"  A dataset built at h{resolution} carries no "
+        f"h{CATALOG_JOIN_RESOLUTION} column, so it cannot be joined against "
+        f"the rest of the catalog\n"
+        f"  on h{CATALOG_JOIN_RESOLUTION} — the universal join key.\n"
+    )
+
+    if user_specified:
+        return (
+            f"⚠ Using h{resolution}, coarser than the "
+            f"h{CATALOG_JOIN_RESOLUTION} catalog join key.\n"
+            f"{consequence}"
+            f"  Proceeding: the resolution was specified explicitly."
+        )
+
+    return (
+        f"⚠ Auto-detected h{resolution} is coarser than the "
+        f"h{CATALOG_JOIN_RESOLUTION} catalog join key.\n"
+        f"{consequence}"
+        f"  Auto-detection targets ~3x the source pixel edge (~9 pixels per "
+        f"cell), which is coarser than the\n"
+        f"  catalog convention of roughly one cell per pixel at this pixel "
+        f"size.\n"
+        f"  Pass --h3-resolution {CATALOG_JOIN_RESOLUTION} to build a "
+        f"joinable dataset, or --h3-resolution {resolution} to make this "
+        f"coarse\n"
+        f"  build a deliberate choice."
+    )
+
+
 def create_mosaic_cog(
     source_urls: List[str],
     output_path: str,
@@ -1072,6 +1157,16 @@ class RasterProcessor:
                 print(f"✓ Using h{h3_resolution} (matches auto-detected resolution)")
 
         self.parent_resolutions = parent_resolutions or []
+
+        # A build with no path to h8 — target too coarse, or h8 missing from the
+        # parents — is silently non-joinable unless we say so (issue #182).
+        join_warning = h3_resolution_join_warning(
+            self.h3_resolution,
+            user_specified=h3_resolution is not None,
+            parent_resolutions=self.parent_resolutions,
+        )
+        if join_warning:
+            print(join_warning)
 
         # Set up DuckDB connection
         self.con = self._setup_duckdb()

--- a/docs/api/raster.md
+++ b/docs/api/raster.md
@@ -21,6 +21,8 @@ Functions
 
 .. autofunction:: cng_datasets.raster.detect_optimal_h3_resolution
 
+.. autofunction:: cng_datasets.raster.h3_resolution_join_warning
+
 .. autofunction:: cng_datasets.raster.create_cog
 
 .. autofunction:: cng_datasets.raster.process_h0_region

--- a/docs/kubernetes_workflows.md
+++ b/docs/kubernetes_workflows.md
@@ -384,8 +384,40 @@ Monitor progress at https://armada-lookout.nrp-nautilus.io
 
 - **Single-pod steps** (setup-bucket, convert, pmtiles, repartition) become one Armada job each
 - **Indexed parallel steps** (hex) are expanded into N individual Armada jobs (one per chunk), each with the chunk index baked into the command. For vector workflows this is up to 200+ jobs; for raster workflows, 122 (one per H3 h0 region)
-- The k8s `priorityClassName: opportunistic` maps to `armada-preemptible`
+- Converted jobs run at the **non-preemptible `armada-default`** priority class (see below)
 - All existing k8s Job YAMLs are still generated alongside the Armada files, so you can switch between backends without regenerating
+
+### Priority Class and Retries
+
+Conversion reads the k8s podSpec (`spec.template.spec`), so **Job-level retry settings do not
+survive it** — `backoffLimit`, `backoffLimitPerIndex` and `maxFailedIndexes` are dropped, and
+Armada has no per-job equivalent (retries are a server-side setting). Generation warns when a
+real retry budget is discarded.
+
+That is why converted jobs default to the non-preemptible `armada-default` rather than
+`armada-preemptible`: a preempted Armada job is
+[not automatically rescheduled](https://nrp.ai/documentation/userdocs/running/scheduling/), so a
+preemptible long job with no retries loses its whole unit of work. The k8s `opportunistic` class
+is deliberately *not* mapped onto `armada-preemptible` for the same reason — an opportunistic pod
+is preempted but recreated by its Job controller, which the Armada equivalent would not be.
+
+Choose the class explicitly with `--armada-priority-class`, which accepts a shorthand or a literal
+class name:
+
+```bash
+cng-datasets workflow ... --backend armada --armada-priority-class preemptible
+```
+
+| Shorthand | Armada class | Preemptible? | Priority |
+|---|---|---|---|
+| `default` (default) | `armada-default` | no | 100 |
+| `preemptible` | `armada-preemptible` | yes | 50 |
+| `high` | `armada-high-priority` | no | 1000 |
+
+Preemptible is the right choice once the unit of work is small enough that losing one to a
+preemption is cheap. The converter currently reproduces the *shape* of the k8s job it reads — one
+Armada job per completion, at the same cpu/memory/runtime — so units are as large as the k8s ones
+until sub-h0 chunking lands (issue #173).
 
 ### Differences from Standard k8s Backend
 
@@ -396,7 +428,8 @@ Monitor progress at https://armada-lookout.nrp-nautilus.io
 | Parallel hex jobs | Single k8s Indexed Job | N individual Armada jobs |
 | Pod limit | Bounded by namespace quota | Armada queues excess jobs |
 | Monitoring | `kubectl logs` | Lookout UI |
-| Priority class | `opportunistic` | `armada-preemptible` |
+| Priority class | `opportunistic` | `armada-default` (set with `--armada-priority-class`) |
+| Retry on failure | Job-level `backoffLimit` | none (dropped in conversion) |
 
 ## Advanced Usage
 

--- a/docs/raster_processing.md
+++ b/docs/raster_processing.md
@@ -75,16 +75,41 @@ print(f"Recommended H3 resolution: {h3_res}")
 
 ### Resolution Mapping
 
-| Pixel Size | Recommended H3 | Use Case |
-|------------|---------------|----------|
-| 0.5-2m | h14-h15 | High-res imagery |
-| 7-25m | h12-h13 | Sentinel/aerial |
-| 30-300m | h9-h10 | Landsat/regional |
-| 1-12km | h7-h9 | Climate/global |
+Detection targets an H3 edge length of ~3x the source pixel width (about 9 source pixels per
+cell):
+
+| Pixel Size | Detected H3 | Use Case |
+|------------|-------------|----------|
+| 0.5-2m | h13-h14 | High-res imagery |
+| 7-25m | h10-h11 | Sentinel/aerial |
+| 30-300m | h7-h10 | Landsat/regional |
+| 1-12km | h4-h6 | Climate/global |
 
 The processor provides helpful feedback when you choose a resolution different from the detected one:
 - **Finer resolution**: "Using h12 instead of detected h10 - will create more cells"
 - **Coarser resolution**: "Using h8 instead of detected h10 - will aggregate more pixels"
+
+### h8 is the catalog join key
+
+The `3x edge` target agrees with the catalog convention (roughly one cell per pixel) at fine
+pixels and diverges as pixels coarsen — a ~1 km global raster detects **h6**, two levels below
+h8. **A dataset whose finest resolution is coarser than h8 carries no `h8` column at all**, so it
+cannot be joined against the rest of the catalog on the universal join key.
+
+A finer target only carries h8 if h8 is among the parent resolutions, and the raster default is
+`--parent-resolutions 0` — so an h10 build emits h10 and h0, and nothing to join on either.
+
+`raster` warns in both cases, naming the consequence and the flag that fixes it. Pass
+`--h3-resolution 8` for a coarse global product, or add `8` to `--parent-resolutions` for a finer
+one, whenever a joinable output matters (issue #182):
+
+```bash
+cng-datasets raster --input chelsa-bio1.tif ... \
+    --h3-resolution 8 --parent-resolutions "7,6,0"
+
+cng-datasets raster --input nlcd-2021.tif ... \
+    --resolution 10 --parent-resolutions "9,8,0"
+```
 
 ## Parameters
 

--- a/tests/test_armada.py
+++ b/tests/test_armada.py
@@ -12,6 +12,8 @@ from cng_datasets.k8s.armada import (
     k8s_indexed_job_to_armada,
     convert_workflow_to_armada,
     save_armada_yaml,
+    resolve_armada_priority_class,
+    DEFAULT_ARMADA_PRIORITY_CLASS,
     _extract_pod_spec,
     _replace_completion_index,
 )
@@ -157,15 +159,25 @@ class TestK8sJobToArmada:
 
         armada_job = result["jobs"][0]
         assert armada_job["namespace"] == "my-ns"
-        assert armada_job["priorityClassName"] == "armada-preemptible"
+        assert armada_job["priorityClassName"] == "armada-default"
         assert "podSpec" in armada_job
         assert armada_job["podSpec"]["containers"][0]["image"] == "alpine:latest"
 
     @pytest.mark.timeout(5)
-    def test_priority_class_mapping(self):
+    def test_opportunistic_does_not_become_preemptible(self):
+        """
+        A k8s 'opportunistic' job must not convert to armada-preemptible.
+
+        Opportunistic pods are preempted but recreated by their Job controller;
+        preempted Armada jobs are not rescheduled at all, and the Job-level
+        retry settings do not survive conversion. The default is therefore
+        non-preemptible (issue #183).
+        """
         job = _make_simple_job()
+        assert job["spec"]["template"]["spec"]["priorityClassName"] == "opportunistic"
         result = k8s_job_to_armada(job, queue="q", job_set_id="s")
-        assert result["jobs"][0]["priorityClassName"] == "armada-preemptible"
+        assert result["jobs"][0]["priorityClassName"] == "armada-default"
+        assert result["jobs"][0]["priorityClassName"] == DEFAULT_ARMADA_PRIORITY_CLASS
 
     @pytest.mark.timeout(5)
     def test_custom_priority_class(self):
@@ -174,6 +186,14 @@ class TestK8sJobToArmada:
             job, queue="q", job_set_id="s", priority_class="armada-default"
         )
         assert result["jobs"][0]["priorityClassName"] == "armada-default"
+
+    @pytest.mark.timeout(5)
+    def test_priority_class_shorthand(self):
+        job = _make_simple_job()
+        result = k8s_job_to_armada(
+            job, queue="q", job_set_id="s", priority_class="preemptible"
+        )
+        assert result["jobs"][0]["priorityClassName"] == "armada-preemptible"
 
     @pytest.mark.timeout(5)
     def test_pod_spec_has_no_priority_class(self):
@@ -225,6 +245,89 @@ class TestK8sIndexedJobToArmada:
         assert result["jobSetId"] == "my-hex"
         for armada_job in result["jobs"]:
             assert armada_job["namespace"] == "bio"
+
+
+class TestResolveArmadaPriorityClass:
+    """Shorthand resolution for --armada-priority-class (issue #183)."""
+
+    @pytest.mark.timeout(5)
+    def test_shorthands(self):
+        assert resolve_armada_priority_class("default") == "armada-default"
+        assert resolve_armada_priority_class("preemptible") == "armada-preemptible"
+        assert resolve_armada_priority_class("high") == "armada-high-priority"
+
+    @pytest.mark.timeout(5)
+    def test_literal_class_passes_through(self):
+        """Cluster-specific class names must stay usable."""
+        assert resolve_armada_priority_class("armada-default") == "armada-default"
+        assert resolve_armada_priority_class("some-other-class") == "some-other-class"
+
+    @pytest.mark.timeout(5)
+    def test_unset_returns_none(self):
+        assert resolve_armada_priority_class(None) is None
+        assert resolve_armada_priority_class("") is None
+
+
+class TestDroppedRetrySettingsWarning:
+    """
+    Conversion takes spec.template.spec, so Job-level retry settings are left
+    behind. That must be announced, not silent (issue #183).
+    """
+
+    @pytest.mark.timeout(5)
+    def test_warns_on_backoff_limit_per_index(self, capsys):
+        job = _make_indexed_job(completions=2)
+        job["spec"]["backoffLimitPerIndex"] = 4
+        job["spec"]["maxFailedIndexes"] = 10
+
+        k8s_indexed_job_to_armada(job, queue="q", job_set_id="hex")
+
+        out = capsys.readouterr().out
+        assert "backoffLimitPerIndex=4" in out
+        assert "maxFailedIndexes=10" in out
+
+    @pytest.mark.timeout(5)
+    def test_no_warning_when_no_retries_were_granted(self, capsys):
+        """backoffLimit=0 grants no retries, so dropping it loses nothing."""
+        job = _make_simple_job()
+        job["spec"]["backoffLimit"] = 0
+
+        k8s_job_to_armada(job, queue="q", job_set_id="s")
+
+        assert "Dropping k8s Job-level retry settings" not in capsys.readouterr().out
+
+    @pytest.mark.timeout(5)
+    def test_no_warning_when_retry_fields_absent(self, capsys):
+        k8s_job_to_armada(_make_simple_job(), queue="q", job_set_id="s")
+        assert "Dropping k8s Job-level retry settings" not in capsys.readouterr().out
+
+    @pytest.mark.timeout(5)
+    def test_preemptible_warning_names_the_lost_unit(self, capsys):
+        """
+        Dropped retries plus preemptible priority is the trap from #183: a
+        preempted Armada job is not rescheduled, so the whole unit is lost.
+        """
+        job = _make_indexed_job(completions=2)
+        job["spec"]["backoffLimitPerIndex"] = 4
+
+        k8s_indexed_job_to_armada(
+            job, queue="q", job_set_id="hex", priority_class="preemptible"
+        )
+
+        out = capsys.readouterr().out
+        assert "not rescheduled" in out
+        assert "--armada-priority-class default" in out
+
+    @pytest.mark.timeout(5)
+    def test_no_preemptible_note_at_default_priority(self, capsys):
+        job = _make_indexed_job(completions=2)
+        job["spec"]["backoffLimitPerIndex"] = 4
+
+        k8s_indexed_job_to_armada(job, queue="q", job_set_id="hex")
+
+        out = capsys.readouterr().out
+        assert "backoffLimitPerIndex=4" in out
+        assert "not rescheduled" not in out
 
 
 class TestSaveArmadaYaml:
@@ -326,6 +429,62 @@ class TestConvertWorkflowToArmada:
                 assert len(spec["jobs"]) == 1, f"{step} should have exactly 1 Armada job"
 
     @pytest.mark.timeout(30)
+    def test_priority_class_forwarded_to_every_job(self, monkeypatch):
+        """
+        convert_workflow_to_armada must forward priority_class, otherwise the
+        class cannot be chosen from the CLI at all (issue #183, finding 3).
+        """
+        import cng_datasets.k8s.workflows as wf
+        monkeypatch.setattr(wf, "_count_source_features", lambda *a, **k: 5000)
+        with tempfile.TemporaryDirectory() as tmpdir:
+            generate_dataset_workflow(
+                dataset_name="test-ds",
+                source_url="https://s3-west.nrp-nautilus.io/public-test/fixtures/test-fixture.gpkg",
+                bucket="test-bucket",
+                output_dir=tmpdir,
+                h3_resolution=10,
+            )
+
+            armada_files = convert_workflow_to_armada(
+                k8s_yaml_dir=tmpdir,
+                dataset_name="test-ds",
+                queue="geo-workflows",
+                priority_class="preemptible",
+            )
+
+            assert armada_files
+            for fpath in armada_files:
+                with open(fpath) as f:
+                    spec = yaml.safe_load(f)
+                for job in spec["jobs"]:
+                    assert job["priorityClassName"] == "armada-preemptible"
+
+    @pytest.mark.timeout(30)
+    def test_default_priority_class_is_non_preemptible(self, monkeypatch):
+        import cng_datasets.k8s.workflows as wf
+        monkeypatch.setattr(wf, "_count_source_features", lambda *a, **k: 5000)
+        with tempfile.TemporaryDirectory() as tmpdir:
+            generate_dataset_workflow(
+                dataset_name="test-ds",
+                source_url="https://s3-west.nrp-nautilus.io/public-test/fixtures/test-fixture.gpkg",
+                bucket="test-bucket",
+                output_dir=tmpdir,
+                h3_resolution=10,
+            )
+
+            armada_files = convert_workflow_to_armada(
+                k8s_yaml_dir=tmpdir,
+                dataset_name="test-ds",
+                queue="geo-workflows",
+            )
+
+            for fpath in armada_files:
+                with open(fpath) as f:
+                    spec = yaml.safe_load(f)
+                for job in spec["jobs"]:
+                    assert job["priorityClassName"] == DEFAULT_ARMADA_PRIORITY_CLASS
+
+    @pytest.mark.timeout(30)
     def test_skips_non_job_files(self):
         with tempfile.TemporaryDirectory() as tmpdir:
             generate_dataset_workflow(
@@ -375,6 +534,26 @@ class TestWorkflowBackendFlag:
             )
             armada_files = list(Path(tmpdir).glob("armada-*.yaml"))
             assert len(armada_files) > 0
+
+    @pytest.mark.timeout(5)
+    def test_raster_armada_priority_class_flag(self):
+        """--armada-priority-class reaches the generated raster Armada YAML."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            generate_raster_workflow(
+                dataset_name="test-raster",
+                source_urls="https://example.com/tile.tif",
+                bucket="test-bucket",
+                output_dir=tmpdir,
+                backend="armada",
+                armada_priority_class="high",
+            )
+
+            hex_file = Path(tmpdir) / "armada-test-raster-hex.yaml"
+            with open(hex_file) as f:
+                spec = yaml.safe_load(f)
+            assert spec["jobs"]
+            for job in spec["jobs"]:
+                assert job["priorityClassName"] == "armada-high-priority"
 
     @pytest.mark.timeout(5)
     def test_raster_backend_armada(self):

--- a/tests/test_raster.py
+++ b/tests/test_raster.py
@@ -535,6 +535,84 @@ class TestH3EdgeLengths:
         assert sig.return_annotation == int or str(sig.return_annotation) == 'int'
 
 
+@requires_gdal
+class TestCatalogJoinResolutionWarning:
+    """
+    A target resolution below h8 carries no h8 column, so the dataset cannot
+    join the rest of the catalog on the universal join key. Auto-detection
+    targets ~3x the source pixel edge and lands on h6 for a ~1 km global
+    raster, so the coarse case must be announced (issue #182).
+    """
+
+    @pytest.mark.timeout(5)
+    def test_no_warning_when_h8_is_present(self):
+        from cng_datasets.raster import h3_resolution_join_warning
+
+        # h8 as the target itself, whatever the parents
+        assert h3_resolution_join_warning(8, user_specified=False, parent_resolutions=[0]) is None
+        assert h3_resolution_join_warning(8, user_specified=True, parent_resolutions=[]) is None
+        # h8 as a requested parent of a finer target
+        for res in (9, 10, 12):
+            assert h3_resolution_join_warning(
+                res, user_specified=True, parent_resolutions=[9, 8, 0]
+            ) is None
+
+    @pytest.mark.timeout(5)
+    def test_fine_target_without_h8_parent_warns(self):
+        """
+        The raster default is --parent-resolutions 0, so an h10 build emits h10
+        and h0 and nothing to join the catalog on (issue #182).
+        """
+        from cng_datasets.raster import h3_resolution_join_warning
+
+        msg = h3_resolution_join_warning(10, user_specified=True, parent_resolutions=[0])
+
+        assert msg is not None
+        assert msg.startswith("⚠")
+        assert "no h8 column" in msg
+        assert "h10, h0" in msg
+        assert "--parent-resolutions" in msg
+
+    @pytest.mark.timeout(5)
+    def test_unknown_parents_skips_the_parent_check(self):
+        """A caller that does not know its parents must not be warned falsely."""
+        from cng_datasets.raster import h3_resolution_join_warning
+
+        assert h3_resolution_join_warning(10, user_specified=True) is None
+
+    @pytest.mark.timeout(5)
+    def test_auto_detected_coarse_resolution_warns_with_remedy(self):
+        from cng_datasets.raster import h3_resolution_join_warning
+
+        msg = h3_resolution_join_warning(6, user_specified=False)
+
+        assert msg is not None
+        assert msg.startswith("⚠")
+        # Names the consequence, not just the number
+        assert "no h8 column" in msg
+        assert "join" in msg
+        # And the actionable remedy
+        assert "--h3-resolution 8" in msg
+
+    @pytest.mark.timeout(5)
+    def test_explicit_coarse_resolution_is_acknowledged_not_second_guessed(self):
+        from cng_datasets.raster import h3_resolution_join_warning
+
+        msg = h3_resolution_join_warning(6, user_specified=True)
+
+        assert msg is not None
+        assert "no h8 column" in msg
+        assert "specified explicitly" in msg
+        # An explicit choice should not be told to pass the flag it just passed
+        assert "--h3-resolution 8" not in msg
+
+    @pytest.mark.timeout(5)
+    def test_join_resolution_is_h8(self):
+        from cng_datasets.raster import CATALOG_JOIN_RESOLUTION
+
+        assert CATALOG_JOIN_RESOLUTION == 8
+
+
 @requires_gdal_array
 class TestCOGOptimization:
     """Test COG creation options and optimizations."""


### PR DESCRIPTION
Closes #182. Addresses findings 2, 3 and 4 of #183 (finding 1 — the converter reproducing k8s pod shape — is structural and stays with #173).

Two silent-wrong-output defaults, both surfaced by the CHELSA bioclimate build (boettiger-lab/data-workflows#564).

## raster: no path to h8 is now announced (#182)

`detect_optimal_h3_resolution` targets ~3x the source pixel edge, which agrees with the catalog convention at fine pixels and diverges as pixels coarsen — a ~1 km global raster detects **h6**, two levels below the h8 join key. A build below h8 carries no `h8` column, so it silently fails to join the catalog.

Per the issue's option 1, detection is unchanged and the coarse case is warned instead, so nothing relying on today's default is retargeted.

While wiring it up, the same failure mode turned out to exist at the **fine** end, and by default: h8 only appears in a finer build if it is among `--parent-resolutions`, whose raster default is `0` alone — so `--resolution 10` with defaults emits h10 and h0 and nothing to join on. The issue asks to warn when there is "no `h8` path", so both cases are covered:

```
⚠ Auto-detected h6 is coarser than the h8 catalog join key.
  A dataset built at h6 carries no h8 column, so it cannot be joined against the rest of the catalog
  on h8 — the universal join key.
  Auto-detection targets ~3x the source pixel edge (~9 pixels per cell), which is coarser than the
  catalog convention of roughly one cell per pixel at this pixel size.
  Pass --h3-resolution 8 to build a joinable dataset, or --h3-resolution 6 to make this coarse
  build a deliberate choice.

⚠ This build emits h10, h0 — no h8 column.
  h8 is the catalog's universal join key, so the output cannot be joined against the
  rest of the catalog. Add 8 to --parent-resolutions to emit it.
```

An explicitly chosen sub-h8 resolution still gets the consequence named, but is acknowledged as deliberate rather than told to pass the flag it just passed.

## armada: the priority class is reachable, and safe by default (#183)

**Finding 3 — `--armada-priority-class` on `workflow` and `raster-workflow`.** `convert_workflow_to_armada` neither accepted nor forwarded a priority class, so from the CLI it could not be chosen at all. Accepts a shorthand (`default`, `preemptible`, `high`) or a literal class name for cluster-specific classes, and the generated-workflow summary now reports the class in effect.

**Finding 2 — the default is now non-preemptible.** Converted jobs default to `armada-default`, and the k8s `opportunistic` class no longer maps onto `armada-preemptible`. An opportunistic pod is preempted but *recreated by its Job controller*; a preempted Armada job is [not rescheduled](https://nrp.ai/documentation/userdocs/running/scheduling/), and the Job-level retry settings do not survive conversion — so the old default turned multi-hour work into preemptible work with neither retry nor rescheduling, strictly worse than the k8s path it converted from. Preemptible is the right default once units are microsliced (#173), not before; `--armada-priority-class preemptible` opts back in. This is a behaviour change for existing `--backend armada` users, noted as breaking in the changelog.

Dropped retry settings are now named rather than discarded silently, with an extra note when the job is also preemptible:

```
⚠ Dropping k8s Job-level retry settings when converting chelsa-hex to Armada: backoffLimitPerIndex=4, maxFailedIndexes=10.
  Armada has no per-job equivalent (retries are a server-side setting), so a failed job stays failed.
  This job is also preemptible, and preempted Armada jobs are not rescheduled — a preemption
  loses the whole unit. Consider --armada-priority-class default for long-running units.
```

Values that grant no retries (a `0`) are not reported, so the generated workflows' own `backoffLimit: 0` steps stay quiet. Suggestion 3 in the issue (mapping `backoffLimitPerIndex` onto an Armada per-job retry setting) is not implemented: Armada exposes no such per-submission field, so the warning says the budget is gone rather than inventing a mapping.

**Finding 4 — stale default queue** `biodiversity` → `geo-workflows`. Both generators pass `queue=namespace` explicitly, so this only affects direct API callers; see the issue thread for the related `--namespace` default.

## Tests

New: the join-warning branches (h8 target, h8 parent, coarse auto vs explicit, missing h8 parent, unknown parents), priority-class shorthand resolution, the dropped-retry warning including its no-op and preemptible cases, and end-to-end plumbing that every converted job in a generated workflow carries the requested class. Existing assertions on the old `armada-preemptible` default were updated, and the `opportunistic` mapping now has an explicit regression test.

The GDAL-dependent tests (`test_raster.py`, `test_cli.py`, and the raster case in `test_armada.py`) cannot run in my sandbox — no system GDAL and no Docker — so they are verified in CI. The offline suite goes from 235 to 246 passing with no new failures; the one new failing test is the raster Armada case, which fails on `ModuleNotFoundError: osgeo` exactly as its pre-existing sibling `test_raster_backend_armada` does on clean main. Warning-text assertions were additionally checked directly against the helper's real source.